### PR TITLE
Metadata load

### DIFF
--- a/DDL.sql
+++ b/DDL.sql
@@ -1,0 +1,179 @@
+-- ========================
+-- Users & Auth (if needed)
+-- ========================
+CREATE TABLE dim_users (
+  user_id         TEXT PRIMARY KEY,      -- internal UUID
+  display_name    TEXT,
+  country         TEXT,
+  created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- ========================
+-- Tracks, Albums, Artists
+-- ========================
+CREATE TABLE dim_tracks (
+  track_id         TEXT PRIMARY KEY, -- UUID
+  track_spotify_id TEXT UNIQUE,
+  track_mbid TEXT UNIQUE,
+  track_isrc       TEXT UNIQUE,
+  track_name       TEXT NOT NULL,
+  album_id         TEXT,                   -- FK → dim_albums
+  duration_ms      INT,
+  explicit         BOOLEAN,
+  created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE dim_albums (
+  album_id         TEXT PRIMARY KEY,       -- MBID preferred; else UUID
+  album_spotify_id TEXT UNIQUE,
+  album_name       TEXT NOT NULL,
+  release_year     INT,
+  label            TEXT
+);
+
+CREATE TABLE dim_artists (
+  artist_id        TEXT PRIMARY KEY,       -- MBID preferred; else UUID
+  artist_spotify_id TEXT UNIQUE,
+  artist_name      TEXT NOT NULL
+);
+
+-- Bridge between tracks and artists (handles features, remixers, etc.)
+CREATE TABLE bridge_track_artists (
+  track_id   TEXT NOT NULL REFERENCES dim_tracks(track_id),
+  artist_id  TEXT NOT NULL REFERENCES dim_artists(artist_id),
+  role       TEXT NOT NULL,                -- 'primary' | 'feature' | 'remixer'
+  PRIMARY KEY (track_id, artist_id, role)
+);
+
+-- ========================
+-- Facts: Listening history
+-- ========================
+CREATE TABLE fact_plays (
+  play_id       TEXT PRIMARY KEY,         -- UUID
+  user_id       TEXT NOT NULL REFERENCES dim_users(user_id),
+  track_id      TEXT NOT NULL REFERENCES dim_tracks(track_id),
+  played_at     TIMESTAMP NOT NULL,
+  context_type  TEXT,                     -- playlist | album | radio | unknown
+  context_id    TEXT,
+  device_type   TEXT,
+  duration_ms   INT,                      -- actual listened ms
+  conn_country  TEXT,                     -- from export: connection country
+  ip_addr       TEXT,                     -- from export: IP address
+  reason_start  TEXT,                     -- from export: reason_start
+  reason_end    TEXT,                     -- from export: reason_end
+  shuffle       BOOLEAN,                  -- from export
+  skipped       BOOLEAN,                  -- from export
+  offline       BOOLEAN,                  -- from export
+  offline_timestamp TIMESTAMP,            -- from export
+  incognito_mode BOOLEAN,                 -- from export
+  UNIQUE(user_id, track_id, played_at)    -- dedup key
+);
+
+-- ========================
+-- Canonical vocabularies
+-- ========================
+CREATE TABLE dim_genres (
+  genre_id       INTEGER PRIMARY KEY,
+  name           TEXT UNIQUE NOT NULL,
+  parent_genre_id INTEGER,
+  level          INTEGER,
+  active         BOOLEAN DEFAULT TRUE
+);
+
+CREATE TABLE dim_moods (
+  mood_id        INTEGER PRIMARY KEY,
+  name           TEXT UNIQUE NOT NULL,
+  active         BOOLEAN DEFAULT TRUE
+);
+
+-- ========================
+-- Raw evidence & mappings
+-- ========================
+CREATE TABLE tag_evidence (
+  entity_type    TEXT NOT NULL,    -- 'track' | 'artist' | 'release'
+  entity_key     TEXT NOT NULL,    -- track_id / artist_id / album_id
+  source         TEXT NOT NULL,    -- 'musicbrainz' | 'lastfm' | 'discogs' | 'theaudiodb'
+  tag_raw        TEXT NOT NULL,    -- exact string from API
+  tag_kind       TEXT NOT NULL,    -- 'genre' | 'mood'
+  weight_raw     REAL,             -- source-provided weight, or 1.0
+  observed_at    TIMESTAMP NOT NULL,
+  PRIMARY KEY (entity_type, entity_key, source, tag_raw, tag_kind)
+);
+
+CREATE TABLE map_genre (
+  source         TEXT NOT NULL,
+  tag_raw        TEXT NOT NULL,
+  genre_id       INTEGER NOT NULL REFERENCES dim_genres(genre_id),
+  confidence     REAL NOT NULL,   -- 0–1
+  PRIMARY KEY (source, tag_raw)
+);
+
+CREATE TABLE map_mood (
+  source         TEXT NOT NULL,
+  tag_raw        TEXT NOT NULL,
+  mood_id        INTEGER NOT NULL REFERENCES dim_moods(mood_id),
+  confidence     REAL NOT NULL,
+  PRIMARY KEY (source, tag_raw)
+);
+
+-- ========================
+-- Normalized track-level
+-- ========================
+CREATE TABLE track_genres (
+  track_id       TEXT NOT NULL REFERENCES dim_tracks(track_id),
+  genre_id       INTEGER NOT NULL REFERENCES dim_genres(genre_id),
+  score          REAL NOT NULL,         -- sums to 1.0 per track
+  method_version TEXT NOT NULL,
+  PRIMARY KEY (track_id, genre_id)
+);
+
+CREATE TABLE track_moods (
+  track_id       TEXT NOT NULL REFERENCES dim_tracks(track_id),
+  mood_id        INTEGER NOT NULL REFERENCES dim_moods(mood_id),
+  score          REAL NOT NULL,         -- sums to 1.0 per track
+  method_version TEXT NOT NULL,
+  PRIMARY KEY (track_id, mood_id)
+);
+
+-- ========================
+-- User rollups
+-- ========================
+CREATE TABLE agg_user_genre_daily (
+  user_id        TEXT NOT NULL REFERENCES dim_users(user_id),
+  date           DATE NOT NULL,
+  genre_id       INTEGER NOT NULL REFERENCES dim_genres(genre_id),
+  plays          INTEGER NOT NULL,
+  ms_listened    BIGINT NOT NULL,
+  avg_score_weighted REAL NOT NULL,
+  PRIMARY KEY (user_id, date, genre_id)
+);
+
+CREATE TABLE agg_user_genre_monthly (
+  user_id        TEXT NOT NULL REFERENCES dim_users(user_id),
+  month          TEXT NOT NULL,    -- 'YYYY-MM'
+  genre_id       INTEGER NOT NULL REFERENCES dim_genres(genre_id),
+  plays          INTEGER NOT NULL,
+  ms_listened    BIGINT NOT NULL,
+  avg_score_weighted REAL NOT NULL,
+  PRIMARY KEY (user_id, month, genre_id)
+);
+
+CREATE TABLE agg_user_mood_daily (
+  user_id        TEXT NOT NULL REFERENCES dim_users(user_id),
+  date           DATE NOT NULL,
+  mood_id        INTEGER NOT NULL REFERENCES dim_moods(mood_id),
+  plays          INTEGER NOT NULL,
+  ms_listened    BIGINT NOT NULL,
+  avg_score_weighted REAL NOT NULL,
+  PRIMARY KEY (user_id, date, mood_id)
+);
+
+CREATE TABLE agg_user_mood_monthly (
+  user_id        TEXT NOT NULL REFERENCES dim_users(user_id),
+  month          TEXT NOT NULL,    -- 'YYYY-MM'
+  mood_id        INTEGER NOT NULL REFERENCES dim_moods(mood_id),
+  plays          INTEGER NOT NULL,
+  ms_listened    BIGINT NOT NULL,
+  avg_score_weighted REAL NOT NULL,
+  PRIMARY KEY (user_id, month, mood_id)
+);

--- a/DDL.sql
+++ b/DDL.sql
@@ -12,28 +12,25 @@ CREATE TABLE dim_users (
 -- Tracks, Albums, Artists
 -- ========================
 CREATE TABLE dim_tracks (
-  track_id         TEXT PRIMARY KEY, -- UUID
-  track_spotify_id TEXT UNIQUE,
-  track_mbid TEXT UNIQUE,
-  track_isrc       TEXT UNIQUE,
+  track_id         TEXT PRIMARY KEY, -- Spotify ID
+  track_mbid TEXT,
+  track_isrc       TEXT,
   track_name       TEXT NOT NULL,
-  album_id         TEXT,                   -- FK → dim_albums
+  album_id         TEXT,                   -- Spotify ID (album)
   duration_ms      INT,
   explicit         BOOLEAN,
   created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE dim_albums (
-  album_id         TEXT PRIMARY KEY,       -- MBID preferred; else UUID
-  album_spotify_id TEXT UNIQUE,
+  album_id         TEXT PRIMARY KEY,       -- Spotify ID
   album_name       TEXT NOT NULL,
   release_year     INT,
   label            TEXT
 );
 
 CREATE TABLE dim_artists (
-  artist_id        TEXT PRIMARY KEY,       -- MBID preferred; else UUID
-  artist_spotify_id TEXT UNIQUE,
+  artist_id        TEXT PRIMARY KEY,       -- Spotify ID
   artist_name      TEXT NOT NULL
 );
 

--- a/SEED.sql
+++ b/SEED.sql
@@ -1,0 +1,14 @@
+CREATE TABLE dim_users (
+  user_id         TEXT PRIMARY KEY,      -- internal UUID
+  display_name    TEXT,
+  country         TEXT,
+  created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+
+INSERT INTO dim_users (user_id, display_name, country) VALUES
+('ben.greenawald', 'Ben Greenawald', 'US'),
+('margo.greenawald', 'Margo Greenawald', 'US'),
+('erin.greenawald', 'Erin Greenawald', 'US'),
+('robby.woo', 'Robby Woo', 'US')
+;

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,133 @@
+
+# TASK.md
+
+## Overview
+
+We are migrating an existing prototype Spotify listening analytics app into a more robust system. The original prototype was built in Python (using Dash) and focused on user listening data and simple aggregations. The new design introduces richer **genre** and **mood** classification using multiple metadata sources, a canonical taxonomy, and a normalized schema for reproducible analytics.
+
+The agent’s role is to help **implement and migrate the prototype** to this new architecture.
+
+---
+
+## Key Goals
+
+1. **Multi-user support** — system should handle multiple users’ listening histories.
+2. **Rich genre + mood enrichment**:
+
+   * Collect raw tags from multiple sources (MusicBrainz, Last.fm, Discogs, TheAudioDB).
+   * Map them to canonical vocabularies (genres, moods).
+   * Compute normalized per-track distributions (summing to 1).
+   * Store both provenance (`tag_evidence`) and normalized scores (`track_genres`, `track_moods`).
+3. **Rollups for analytics**:
+
+   * Daily and monthly aggregations of genres and moods per user.
+   * Enable queries like “top genres/moods over last 90 days” or “genre drift over time.”
+4. **Advanced queries**:
+
+   * Support album-level statistics (e.g. *median number of track plays per album*).
+   * Include tracks with zero plays when computing album medians.
+5. **Local-first design**:
+
+   * No OAuth server or online auth flows required (Spotify data comes from extended streaming history JSON exports).
+   * API tokens for external sources can be stored locally in `.env` (if needed).
+
+---
+
+## Data Flow (Track → Genres/Moods)
+
+1. **Ingest** Spotify history (`fact_plays`) with track IDs, play timestamps, durations.
+2. **Resolve IDs** (via ISRC → MusicBrainz MBID; fallback fuzzy search).
+3. **Collect raw evidence**:
+
+   * MusicBrainz: recording/release/artist genres + tags.
+   * Discogs: release/artist genres & styles.
+   * Last.fm: `track.getTopTags` + `artist.getTopTags` (community tags).
+   * TheAudioDB: explicit `Mood` and `Style` fields.
+4. **Store evidence** in `tag_evidence`.
+5. **Map evidence → canonical vocabularies** via `map_genre` and `map_mood`.
+6. **Compute effective weights**:
+   `effective_weight = raw_weight × mapping_confidence × source_prior`
+7. **Aggregate per track**, normalize to probabilities → `track_genres` and `track_moods`.
+8. **Roll up** to per-user daily/monthly aggregates.
+
+---
+
+## Database Schema (DDL)
+
+### Core Dimensions
+
+* `dim_users` — users
+* `dim_tracks`, `dim_albums`, `dim_artists` — identity tables
+* `bridge_track_artists` — many-to-many track ↔ artist
+* `fact_plays` — user listening history (track-level)
+
+### Canonical Vocabularies
+
+* `dim_genres` — canonical genre list
+* `dim_moods` — canonical mood list
+
+### Evidence & Mapping
+
+* `tag_evidence` — raw tags from external sources (with provenance, weights)
+* `map_genre` — source-specific tag → genre mapping (with confidence)
+* `map_mood` — source-specific tag → mood mapping (with confidence)
+
+### Normalized Per-track
+
+* `track_genres` — normalized genre distribution per track
+* `track_moods` — normalized mood distribution per track
+
+### Aggregates
+
+* `agg_user_genre_daily` / `agg_user_genre_monthly`
+* `agg_user_mood_daily` / `agg_user_mood_monthly`
+
+(See `music_schema_proposed.sql` for full DDL.)
+
+---
+
+## Key Query Example (album medians)
+
+For each user and year:
+
+* Identify albums they listened to.
+* Gather **all tracks** from those albums (even if not played).
+* Count plays per track (0 if none).
+* Compute **median play count** across all tracks in album.
+
+---
+
+## Frontend Analytics
+
+* Prototype built in **Dash**.
+* Migration path options:
+
+  * **Streamlit** for faster Python-native iteration.
+  * Or **Next.js + FastAPI** for a more polished product UI.
+* Analytics features to include:
+
+  * Genre/mood distributions over time.
+  * Heatmaps (genre × week, mood × hour).
+  * Album-level medians.
+  * Diversity metrics (entropy).
+
+---
+
+## Deliverables for Migration
+
+1. Implement the new schema in the DB (SQLite/DuckDB/Postgres-compatible).
+2. Build ETL scripts:
+
+   * Ingest Spotify exports.
+   * Enrich with external metadata.
+   * Normalize into `track_genres` / `track_moods`.
+   * Compute rollups.
+3. Adapt frontend to read from new rollups and display:
+
+   * Genre/mood trends, heatmaps, and diversity metrics.
+   * Album-level median play counts.
+4. Ensure reproducibility:
+
+   * Version taxonomy files (e.g., `genres_taxonomy.yaml` + `moods_taxonomy.yaml`).
+   * Store `method_version` in normalized tables.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "duckdb>=1.3.2",
 ]
 
+[project.scripts]
+bsw = "src.cli:main"
+
 [dependency-groups]
 dev = [
     "dash[testing]>=2.18.2",

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -261,10 +261,6 @@ def load_api_data() -> SpotifyData:
 def populate_missing_track_isrcs(
     *,
     db_path: str | Path,
-    client_id: str | None = None,
-    client_secret: str | None = None,
-    cache_dir: str | os.PathLike[str] | None = None,
-    limit: int | None = None,
 ) -> int:
     """Populate `dim_tracks.track_isrc` where NULL using Spotify metadata.
 
@@ -287,7 +283,7 @@ def populate_missing_track_isrcs(
     # 1) Discover targets from the DB
     conn = duckdb.connect(str(db_path))
     try:
-        rows = conn.execute(
+        _ = conn.execute(
             """
             SELECT track_id
             FROM dim_tracks
@@ -298,62 +294,358 @@ def populate_missing_track_isrcs(
     finally:
         conn.close()
 
+
+def populate_duration_and_explicit(
+    *,
+    db_path: str | Path,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    cache_dir: str | os.PathLike[str] | None = None,
+    limit: int | None = None,
+) -> tuple[int, int]:
+    """Populate `dim_tracks.duration_ms` and `dim_tracks.explicit` when NULL.
+
+    Fetches track metadata for tracks missing either value and updates them.
+
+    Returns a tuple: (duration_rows_updated, explicit_rows_updated).
+    """
+    # 1) Discover targets from the DB
+    conn = duckdb.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            """
+            SELECT track_id
+            FROM dim_tracks
+            WHERE (duration_ms IS NULL OR explicit IS NULL)
+            ORDER BY track_id
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
     spotify_ids: list[str] = [r[0] for r in rows if r and r[0]]
     if limit is not None:
         spotify_ids = spotify_ids[: max(0, int(limit))]
     if not spotify_ids:
-        return 0
+        return (0, 0)
 
-    # 2) Fetch data (using cache when available)
+    # 2) Fetch metadata (uses cache when available)
     collector = SpotifyDataCollector(
         client_id=client_id, client_secret=client_secret, cache_dir=cache_dir
     )
     tracks = collector.fetch_tracks(spotify_ids)
 
-    # 3) Build update mapping: track_id (Spotify ID) -> isrc
-    updates: list[tuple[str, str]] = []
+    # 3) Build update mapping
+    records: list[tuple[str, int | None, bool | None]] = []
     for t in tracks:
-        try:
-            tid = t.get("id")
-            isrc = (t.get("external_ids") or {}).get("isrc")
-        except Exception as e:
-            print(f"Error processing track data {t}: {e}")
-            tid = None
-            isrc = None
-        if not tid or not isrc:
+        tid = t.get("id")
+        if not tid:
             continue
-        updates.append((tid, isrc))
+        dur = t.get("duration_ms")
+        try:
+            dur_int = int(dur) if dur is not None else None
+        except Exception:
+            dur_int = None
+        explicit_val = t.get("explicit")
+        explicit_bool = bool(explicit_val) if explicit_val is not None else None
+        records.append((tid, dur_int, explicit_bool))
 
-    if not updates:
-        return 0
+    if not records:
+        return (0, 0)
 
-    # 4) Bulk update into DuckDB
-    df_updates = pd.DataFrame(updates, columns=["track_id", "track_isrc"])
+    df_updates = pd.DataFrame(records, columns=["track_id", "duration_ms", "explicit"])
     conn = duckdb.connect(str(db_path))
     try:
         conn.execute("BEGIN TRANSACTION;")
         conn.register("df_updates", df_updates)
-        # Avoid violating UNIQUE(track_isrc): only set ISRCs not already present
-        conn.execute(
-            """
-            UPDATE dim_tracks AS d
-            SET track_isrc = u.track_isrc
-            FROM df_updates AS u
-            WHERE d.track_id = u.track_id
-              AND d.track_isrc IS NULL
-            """
-        )
-        # Count rows that match the updated mapping now
-        updated = conn.execute(
+
+        # Pre-compute how many rows will be newly populated
+        duration_to_set = conn.execute(
             """
             SELECT COUNT(*)
             FROM dim_tracks d
             JOIN df_updates u ON d.track_id = u.track_id
-            WHERE d.track_isrc = u.track_isrc
+            WHERE d.duration_ms IS NULL AND u.duration_ms IS NOT NULL
             """
         ).fetchone()[0]
+        explicit_to_set = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM dim_tracks d
+            JOIN df_updates u ON d.track_id = u.track_id
+            WHERE d.explicit IS NULL AND u.explicit IS NOT NULL
+            """
+        ).fetchone()[0]
+
+        conn.execute(
+            """
+            UPDATE dim_tracks AS d
+            SET
+              duration_ms = COALESCE(d.duration_ms, u.duration_ms),
+              explicit     = COALESCE(d.explicit, u.explicit)
+            FROM df_updates AS u
+            WHERE d.track_id = u.track_id
+              AND (d.duration_ms IS NULL OR d.explicit IS NULL)
+            """
+        )
         conn.execute("COMMIT;")
-        return int(updated)
+        return int(duration_to_set), int(explicit_to_set)
+    finally:
+        conn.close()
+
+
+def populate_track_albums(
+    *,
+    db_path: str | Path,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    cache_dir: str | os.PathLike[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Populate `dim_tracks.album_id` and upsert albums into `dim_albums`.
+
+    Strategy:
+    - Find tracks with NULL `album_id`.
+    - Fetch track metadata, extract album IDs/names/years.
+    - Insert missing albums into `dim_albums` (anti-join).
+    - Update `dim_tracks.album_id` where NULL.
+
+    Returns counts: {"albums_inserted": x, "tracks_updated": y}.
+    """
+    # 1) Discover targets
+    conn = duckdb.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            """
+            SELECT track_id
+            FROM dim_tracks
+            WHERE album_id IS NULL
+            ORDER BY track_id
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    track_ids: list[str] = [r[0] for r in rows if r and r[0]]
+    if limit is not None:
+        track_ids = track_ids[: max(0, int(limit))]
+    if not track_ids:
+        return {"albums_inserted": 0, "tracks_updated": 0}
+
+    # 2) Fetch track metadata
+    collector = SpotifyDataCollector(
+        client_id=client_id, client_secret=client_secret, cache_dir=cache_dir
+    )
+    tracks = collector.fetch_tracks(track_ids)
+
+    # 3) Build frames for albums and track->album mapping
+    album_rows: list[tuple[str, str, int | None]] = []
+    track_album_rows: list[tuple[str, str]] = []
+    for t in tracks:
+        tid = t.get("id")
+        album = t.get("album") or {}
+        aid = album.get("id")
+        aname_raw = album.get("name")
+        # Parse release year (YYYY prefix of release_date)
+        release_date = album.get("release_date")
+        try:
+            release_year = int(str(release_date)[:4]) if release_date else None
+        except Exception:
+            release_year = None
+        if aid:
+            aname = (
+                aname_raw
+                if (aname_raw is not None and str(aname_raw).strip())
+                else f"spotify:{aid}"
+            )
+            album_rows.append((aid, aname, release_year))
+        if tid and aid:
+            track_album_rows.append((tid, aid))
+
+    if not track_album_rows:
+        return {"albums_inserted": 0, "tracks_updated": 0}
+
+    df_albums = pd.DataFrame(
+        album_rows, columns=["album_id", "album_name", "release_year"]
+    ).drop_duplicates(subset=["album_id"], keep="first")
+    df_track_album = pd.DataFrame(
+        track_album_rows, columns=["track_id", "album_id"]
+    ).drop_duplicates(subset=["track_id"], keep="first")
+
+    # 4) Apply DB changes
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute("BEGIN TRANSACTION;")
+        conn.register("df_albums", df_albums)
+        conn.register("df_track_album", df_track_album)
+
+        albums_to_insert = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM df_albums a
+            ANTI JOIN dim_albums d ON d.album_id = a.album_id
+            """
+        ).fetchone()[0]
+
+        tracks_to_update = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM dim_tracks d
+            JOIN df_track_album u ON d.track_id = u.track_id
+            WHERE d.album_id IS NULL AND u.album_id IS NOT NULL
+            """
+        ).fetchone()[0]
+
+        conn.execute(
+            """
+            INSERT INTO dim_albums (album_id, album_name, release_year, label)
+            SELECT a.album_id, a.album_name, a.release_year, NULL
+            FROM df_albums a
+            ANTI JOIN dim_albums d ON d.album_id = a.album_id
+            """
+        )
+
+        conn.execute(
+            """
+            UPDATE dim_tracks AS d
+            SET album_id = COALESCE(d.album_id, u.album_id)
+            FROM df_track_album AS u
+            WHERE d.track_id = u.track_id AND d.album_id IS NULL
+            """
+        )
+
+        conn.execute("COMMIT;")
+        return {"albums_inserted": int(albums_to_insert), "tracks_updated": int(tracks_to_update)}
+    finally:
+        conn.close()
+
+
+def populate_track_artists(
+    *,
+    db_path: str | Path,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    cache_dir: str | os.PathLike[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Populate `dim_artists` and `bridge_track_artists` from track metadata.
+
+    Strategy:
+    - Find tracks that currently have no artist bridge rows.
+    - Fetch track metadata and extract artist IDs/names and roles.
+    - Insert missing artists into `dim_artists` (anti-join).
+    - Insert missing bridge rows into `bridge_track_artists` (anti-join).
+
+    Returns counts: {"artists_inserted": x, "bridges_inserted": y}.
+    """
+    # 1) Identify tracks lacking any artist bridges
+    conn = duckdb.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            """
+            SELECT t.track_id
+            FROM dim_tracks t
+            LEFT JOIN bridge_track_artists b ON b.track_id = t.track_id
+            WHERE b.track_id IS NULL
+            ORDER BY t.track_id
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    track_ids: list[str] = [r[0] for r in rows if r and r[0]]
+    if limit is not None:
+        track_ids = track_ids[: max(0, int(limit))]
+    if not track_ids:
+        return {"artists_inserted": 0, "bridges_inserted": 0}
+
+    # 2) Fetch tracks metadata
+    collector = SpotifyDataCollector(
+        client_id=client_id, client_secret=client_secret, cache_dir=cache_dir
+    )
+    tracks = collector.fetch_tracks(track_ids)
+
+    # 3) Build frames for artists and bridges
+    artist_rows: list[tuple[str, str]] = []
+    bridge_rows: list[tuple[str, str, str]] = []  # track_id, artist_id, role
+    for t in tracks:
+        tid = t.get("id")
+        artists = t.get("artists") or []
+        for idx, a in enumerate(artists):
+            aid = a.get("id")
+            aname_raw = a.get("name")
+            if not aid:
+                continue
+            role = "primary" if idx == 0 else "feature"
+            aname = (
+                aname_raw
+                if (aname_raw is not None and str(aname_raw).strip())
+                else f"spotify:{aid}"
+            )
+            artist_rows.append((aid, aname))
+            if tid:
+                bridge_rows.append((tid, aid, role))
+
+    if not bridge_rows:
+        return {"artists_inserted": 0, "bridges_inserted": 0}
+
+    df_artists = pd.DataFrame(artist_rows, columns=["artist_id", "artist_name"]).drop_duplicates(
+        subset=["artist_id"], keep="first"
+    )
+    df_bridge = pd.DataFrame(
+        bridge_rows, columns=["track_id", "artist_id", "role"]
+    ).drop_duplicates()
+
+    # 4) Apply DB changes
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute("BEGIN TRANSACTION;")
+        conn.register("df_artists", df_artists)
+        conn.register("df_bridge", df_bridge)
+
+        artists_to_insert = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM df_artists a
+            ANTI JOIN dim_artists d ON d.artist_id = a.artist_id
+            """
+        ).fetchone()[0]
+
+        bridges_to_insert = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM df_bridge b
+            ANTI JOIN bridge_track_artists d
+              ON d.track_id = b.track_id AND d.artist_id = b.artist_id AND d.role = b.role
+            """
+        ).fetchone()[0]
+
+        conn.execute(
+            """
+            INSERT INTO dim_artists (artist_id, artist_name)
+            SELECT a.artist_id, a.artist_name
+            FROM df_artists a
+            ANTI JOIN dim_artists d ON d.artist_id = a.artist_id
+            """
+        )
+
+        conn.execute(
+            """
+            INSERT INTO bridge_track_artists (track_id, artist_id, role)
+            SELECT b.track_id, b.artist_id, b.role
+            FROM df_bridge b
+            -- Ensure the referenced track exists to satisfy FK
+            JOIN dim_tracks t ON t.track_id = b.track_id
+            ANTI JOIN bridge_track_artists d
+              ON d.track_id = b.track_id AND d.artist_id = b.artist_id AND d.role = b.role
+            """
+        )
+
+        conn.execute("COMMIT;")
+        return {
+            "artists_inserted": int(artists_to_insert),
+            "bridges_inserted": int(bridges_to_insert),
+        }
     finally:
         conn.close()
 
@@ -572,6 +864,125 @@ def populate_track_metadata(
         )
         conn.execute("COMMIT;")
         return int(duration_to_set), int(explicit_to_set)
+    finally:
+        conn.close()
+
+
+def populate_tracks_from_cached_albums(
+    *,
+    db_path: str | Path,
+    cache_dir: str | os.PathLike[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Load tracks listed inside cached album JSONs into `dim_tracks`.
+
+    - Scans `cache_dir/albums/*.json` for album payloads.
+    - Extracts each track from `album["tracks"]["items"]` with basic metadata.
+    - Inserts missing rows into `dim_tracks` and fills NULL metadata for existing rows.
+
+    Returns counts: {"albums_scanned": a, "tracks_inserted": i, "tracks_updated": u}.
+    """
+    # Determine cache directory (default to collector default)
+    cache_env = os.getenv("SPOTIFY_API_CACHE_DIR")
+    cache_root = Path(cache_dir or cache_env or "data/api/cache")
+    albums_dir = cache_root / "albums"
+    if not albums_dir.exists():
+        return {"albums_scanned": 0, "tracks_inserted": 0, "tracks_updated": 0}
+
+    album_files = sorted(albums_dir.glob("*.json"))
+    if limit is not None:
+        album_files = album_files[: max(0, int(limit))]
+
+    rows: list[tuple[str, str, str | None, int | None, bool | None]] = []
+    albums_scanned = 0
+    for path in album_files:
+        try:
+            with open(path, encoding="utf-8") as f:
+                album = json.load(f)
+        except Exception:
+            continue
+        albums_scanned += 1
+        aid = album.get("id")
+        tracks_obj = album.get("tracks") or {}
+        items = tracks_obj.get("items") or []
+        for t in items:
+            tid = t.get("id")
+            if not tid:
+                continue
+            name_raw = t.get("name")
+            name = (
+                name_raw if (name_raw is not None and str(name_raw).strip()) else f"spotify:{tid}"
+            )
+            dur = t.get("duration_ms")
+            try:
+                duration_ms = int(dur) if dur is not None else None
+            except Exception:
+                duration_ms = None
+            explicit_val = t.get("explicit")
+            explicit_bool = bool(explicit_val) if explicit_val is not None else None
+            rows.append((tid, name, aid, duration_ms, explicit_bool))
+
+    if not rows:
+        return {"albums_scanned": albums_scanned, "tracks_inserted": 0, "tracks_updated": 0}
+
+    df_tracks = pd.DataFrame(
+        rows, columns=["track_id", "track_name", "album_id", "duration_ms", "explicit"]
+    ).drop_duplicates(subset=["track_id"], keep="first")
+
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute("BEGIN TRANSACTION;")
+        conn.register("df_tracks", df_tracks)
+
+        tracks_to_insert = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM df_tracks t
+            ANTI JOIN dim_tracks d ON d.track_id = t.track_id
+            """
+        ).fetchone()[0]
+
+        tracks_to_update = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM dim_tracks d
+            JOIN df_tracks u ON d.track_id = u.track_id
+            WHERE (d.album_id IS NULL AND u.album_id IS NOT NULL)
+               OR (d.duration_ms IS NULL AND u.duration_ms IS NOT NULL)
+               OR (d.explicit IS NULL AND u.explicit IS NOT NULL)
+               OR (d.track_name IS NULL AND u.track_name IS NOT NULL)
+            """
+        ).fetchone()[0]
+
+        conn.execute(
+            """
+            INSERT INTO dim_tracks (track_id, track_name, album_id, duration_ms, explicit)
+            SELECT t.track_id, t.track_name, t.album_id, t.duration_ms, t.explicit
+            FROM df_tracks t
+            ANTI JOIN dim_tracks d ON d.track_id = t.track_id
+            """
+        )
+
+        conn.execute(
+            """
+            UPDATE dim_tracks AS d
+            SET
+              track_name  = COALESCE(d.track_name, u.track_name),
+              album_id    = COALESCE(d.album_id, u.album_id),
+              duration_ms = COALESCE(d.duration_ms, u.duration_ms),
+              explicit    = COALESCE(d.explicit, u.explicit)
+            FROM df_tracks AS u
+            WHERE d.track_id = u.track_id
+              AND (d.album_id IS NULL OR d.duration_ms IS NULL OR d.explicit IS NULL OR d.track_name IS NULL)
+            """
+        )
+
+        conn.execute("COMMIT;")
+        return {
+            "albums_scanned": int(albums_scanned),
+            "tracks_inserted": int(tracks_to_insert),
+            "tracks_updated": int(tracks_to_update),
+        }
     finally:
         conn.close()
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,112 @@
+"""Simple CLI for Better Spotify Wrapped tasks.
+
+Provides an `ingest-history` command to load Spotify listening history into
+the normalized DuckDB schema (see DDL.sql).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import duckdb
+
+from .db_ingest import IngestResult, load_history_into_fact_plays
+
+
+def _maybe_apply_ddl(db_path: Path, ddl_path: Path) -> None:
+    if not ddl_path.exists():
+        raise click.ClickException(f"DDL file not found: {ddl_path}")
+    conn = duckdb.connect(str(db_path))
+    try:
+        with ddl_path.open("r", encoding="utf-8") as f:
+            sql = f.read()
+        # Naively split on semicolons to execute multiple statements
+        statements = [s.strip() for s in sql.split(";") if s.strip()]
+        for stmt in statements:
+            conn.execute(stmt)
+    finally:
+        conn.close()
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def main() -> None:
+    """Better Spotify Wrapped CLI."""
+
+
+@main.command("ingest-history")
+@click.option(
+    "--db",
+    "db_path",
+    type=click.Path(path_type=Path),
+    default=Path("data/db/music.db"),
+    show_default=True,
+    help="Path to DuckDB database file.",
+)
+@click.option(
+    "--user-id",
+    type=str,
+    required=True,
+    help="User UUID. If omitted, derived deterministically from --user-name.",
+)
+@click.option(
+    "--history-dir",
+    type=click.Path(path_type=Path, exists=True, file_okay=False),
+    required=True,
+    help="Directory containing Spotify JSON exports (listening_history).",
+)
+@click.option(
+    "--apply-ddl/--no-apply-ddl",
+    default=False,
+    show_default=True,
+    help="Apply DDL.sql to the database before ingest.",
+)
+@click.option(
+    "--ddl",
+    "ddl_path",
+    type=click.Path(path_type=Path),
+    default=Path("DDL.sql"),
+    show_default=True,
+    help="Path to DDL file (used with --apply-ddl).",
+)
+def ingest_history(
+    db_path: Path,
+    user_id: str,
+    history_dir: Path,
+    apply_ddl: bool,
+    ddl_path: Path,
+) -> None:
+    """Load listening history JSON files into `fact_plays`.
+
+    Example:
+      bsw ingest-history --user-name egreenawald \
+        --db data/db/music.db \
+        --history-dir data/egreenawald/listening_history \
+        --apply-ddl
+    """
+    if apply_ddl:
+        click.echo(f"Applying DDL from {ddl_path} to {db_path}...")
+        _maybe_apply_ddl(db_path, ddl_path)
+
+    click.echo(f"Ingesting history from {history_dir} into {db_path} for user {user_id}")
+
+    res: IngestResult = load_history_into_fact_plays(
+        db_path=db_path,
+        user_id=user_id,
+        history_dir=history_dir,
+    )
+
+    click.echo(
+        " | ".join(
+            [
+                f"inserted_plays={res.inserted_plays}",
+                f"deduped_plays={res.deduped_plays}",
+                f"inserted_tracks={res.inserted_tracks}",
+                f"existing_tracks={res.existing_tracks}",
+            ]
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/db_ingest.py
+++ b/src/db_ingest.py
@@ -1,0 +1,413 @@
+"""Database ingestion utilities for loading Spotify listening history.
+
+This module provides a function to load listening history JSON records into the
+normalized schema defined in DDL.sql, specifically inserting into `fact_plays`
+and ensuring minimal supporting rows exist in `dim_users` and `dim_tracks`.
+
+Assumptions/Notes:
+- Tables are created ahead of time by applying `DDL.sql` to the DuckDB DB.
+- We only ingest music track plays (skip podcast episodes).
+- `track_id` is a stable UUID v5 derived from the Spotify Track ID so it can be
+  canonicalized later while remaining stable across runs.
+- Minimal `dim_tracks` attributes are populated from the history export; fields
+  like `album_id`, `duration_ms` of the track, and `explicit` may be unknown.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+# Local import kept optional to avoid hard dependency; function accepts either
+# a directory path of JSON exports or a prebuilt DataFrame of records.
+try:
+    from src.io import load_spotify_history  # type: ignore
+except Exception:  # pragma: no cover - defensive import
+    load_spotify_history = None  # type: ignore
+
+
+@dataclass
+class IngestResult:
+    inserted_plays: int
+    deduped_plays: int
+    inserted_tracks: int
+    existing_tracks: int
+
+
+SPOTIFY_TRACK_NAMESPACE = uuid.NAMESPACE_URL
+
+
+def _stable_track_uuid(spotify_track_id: str) -> str:
+    """Derive a stable UUID for `dim_tracks.track_id` from a Spotify track ID.
+
+    Uses UUID v5 on the URL namespace with the name "spotify:track:{id}".
+    """
+    name = f"spotify:track:{spotify_track_id}"
+    return str(uuid.uuid5(SPOTIFY_TRACK_NAMESPACE, name))
+
+
+def _extract_spotify_track_id(uri: str | None) -> str | None:
+    if not uri:
+        return None
+    # Accept both `spotify:track:ID` and `https://open.spotify.com/track/ID` forms
+    if uri.startswith("spotify:track:"):
+        return uri.split(":")[-1]
+    if "open.spotify.com/track/" in uri:
+        # Strip query params if present
+        part = uri.split("open.spotify.com/track/")[-1]
+        return part.split("?")[0]
+    return None
+
+
+def _to_timestamp(ts: object) -> str | None:
+    """Normalize input timestamp to ISO 8601 string without timezone.
+
+    Accepts strings or pandas Timestamps. Returns ISO-like string that SQLite
+    can store as TEXT or NUMERIC and be compatible with `TIMESTAMP`.
+    """
+    if ts is None:
+        return None
+    if isinstance(ts, pd.Timestamp):
+        if ts.tzinfo is not None:
+            ts = ts.tz_convert(None)  # type: ignore[assignment]
+        return ts.to_pydatetime().isoformat(sep=" ", timespec="seconds")
+    if isinstance(ts, str):
+        try:
+            parsed = pd.to_datetime(ts, errors="coerce")
+            if pd.isna(parsed):
+                return None
+            if parsed.tzinfo is not None:
+                parsed = parsed.tz_convert(None)
+            return parsed.to_pydatetime().isoformat(sep=" ", timespec="seconds")
+        except Exception:
+            return None
+    if isinstance(ts, dt.datetime):
+        if ts.tzinfo is not None:
+            ts = ts.astimezone(dt.timezone.utc).replace(tzinfo=None)
+        return ts.isoformat(sep=" ", timespec="seconds")
+    return None
+
+
+def _ensure_user(conn: duckdb.DuckDBPyConnection, user_id: str) -> None:
+    exists = conn.execute(
+        "SELECT 1 FROM dim_users WHERE user_id = ? LIMIT 1",
+        [user_id],
+    ).fetchone()
+    if not exists:
+        conn.execute(
+            "INSERT INTO dim_users (user_id) VALUES (?)",
+            [user_id],
+        )
+
+
+def _upsert_track(
+    conn: duckdb.DuckDBPyConnection, *, track_spotify_id: str, track_name: str | None
+) -> bool:
+    """Insert a row into `dim_tracks` if it does not already exist.
+
+    Returns True if a new row was inserted; False if it already existed.
+    """
+    track_id = _stable_track_uuid(track_spotify_id)
+    # Ensure a non-null track_name to satisfy NOT NULL constraint
+    safe_name = (
+        track_name
+        if (track_name is not None and str(track_name).strip())
+        else f"spotify:{track_spotify_id}"
+    )
+    exists = conn.execute(
+        "SELECT 1 FROM dim_tracks WHERE track_spotify_id = ? LIMIT 1",
+        [track_spotify_id],
+    ).fetchone()
+    if exists:
+        return False
+    conn.execute(
+        """
+        INSERT INTO dim_tracks (
+            track_id, track_spotify_id, track_name, album_id, duration_ms, explicit
+        ) VALUES (?, ?, ?, NULL, NULL, NULL)
+        """,
+        [track_id, track_spotify_id, safe_name],
+    )
+    return True
+
+
+def _insert_play(
+    conn: duckdb.DuckDBPyConnection,
+    *,
+    user_id: str,
+    track_spotify_id: str,
+    played_at_iso: str,
+    device_type: str | None,
+    duration_ms: int | None,
+) -> bool:
+    track_id = _stable_track_uuid(track_spotify_id)
+    play_id = str(uuid.uuid4())
+    exists = conn.execute(
+        "SELECT 1 FROM fact_plays WHERE user_id = ? AND track_id = ? AND played_at = ? LIMIT 1",
+        [user_id, track_id, played_at_iso],
+    ).fetchone()
+    if exists:
+        return False
+    conn.execute(
+        """
+        INSERT INTO fact_plays (
+            play_id,
+            user_id,
+            track_id,
+            played_at,
+            context_type,
+            context_id,
+            device_type,
+            duration_ms,
+            conn_country,
+            ip_addr,
+            reason_start,
+            reason_end,
+            shuffle,
+            skipped,
+            offline,
+            offline_timestamp,
+            incognito_mode
+        ) VALUES (
+            ?, ?, ?, ?,
+            NULL, NULL,
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        [
+            play_id,
+            user_id,
+            track_id,
+            played_at_iso,
+            device_type,
+            duration_ms,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+    )
+    return True
+
+
+def load_history_into_fact_plays(
+    *,
+    db_path: str | Path,
+    user_id: str,
+    history_dir: str | Path | None = None,
+) -> IngestResult:
+    """Load listening history into `fact_plays` and supporting dims.
+
+    Provide either `history_dir` (a directory with Spotify JSON export files)
+    or `history_df` (a preloaded DataFrame). Podcast plays (episode rows) are
+    skipped; only music tracks with a Spotify track URI are ingested.
+
+    Args:
+        db_path: Path to SQLite DB (e.g., `data/db/music.db`).
+        user_id: Application-level user identifier (UUID string).
+        history_dir: Directory containing `*.json` history files.
+
+    Returns:
+        IngestResult: counts of inserted vs deduped records.
+    """
+
+    history_df = load_spotify_history(str(history_dir))  # type: ignore[arg-type]
+
+    # Normalize and filter rows
+    df = history_df.copy()
+
+    # Deduplicate
+    df = df.drop_duplicates(subset=["spotify_track_uri", "ts"], keep="first")
+
+    # Ensure timestamp is string ISO
+    df["played_at_iso"] = df["ts"].apply(_to_timestamp)
+
+    # Extract Spotify track IDs
+    df["spotify_track_id_only"] = df["spotify_track_uri"].apply(_extract_spotify_track_id)
+
+    # Filter to track plays only
+    mask_tracks = df["spotify_track_id_only"].notna() & df["played_at_iso"].notna()
+    if "spotify_episode_uri" in df.columns:
+        mask_tracks &= df["spotify_episode_uri"].isna()
+    if "episode_name" in df.columns:
+        mask_tracks &= df["episode_name"].isna()
+
+    df_tracks = df.loc[mask_tracks].copy()
+
+    # Prepare bulk frames
+    # Tracks to consider
+    tracks_cols = [
+        "spotify_track_id_only",
+        "master_metadata_track_name",
+    ]
+    tracks_df = (
+        df_tracks[tracks_cols]
+        .dropna(subset=["spotify_track_id_only"])  # keep only rows with track ids
+        .drop_duplicates(subset=["spotify_track_id_only"])
+        .rename(columns={"master_metadata_track_name": "track_name"})
+        .reset_index(drop=True)
+    )
+    # Derive track_id and safe track_name
+    if not tracks_df.empty:
+        tracks_df["track_id"] = tracks_df["spotify_track_id_only"].apply(_stable_track_uuid)
+        tracks_df["track_name"] = tracks_df.apply(
+            lambda r: r["track_name"]
+            if (pd.notna(r["track_name"]) and str(r["track_name"]).strip())
+            else f"spotify:{r['spotify_track_id_only']}",
+            axis=1,
+        )
+
+    # Plays to consider
+    def _clean_ms(v: object) -> int | None:
+        if v is None:
+            return None
+        if isinstance(v, float) and pd.isna(v):
+            return None
+        try:
+            return int(v)  # type: ignore[arg-type]
+        except Exception:
+            return None
+
+    plays_df = pd.DataFrame()
+    if not df_tracks.empty:
+        plays_df = pd.DataFrame(
+            {
+                "play_id": [str(uuid.uuid4()) for _ in range(len(df_tracks))],
+                "user_id": user_id,
+                "track_id": df_tracks["spotify_track_id_only"].apply(_stable_track_uuid),
+                "played_at": df_tracks["played_at_iso"],
+                "device_type": df_tracks.get("platform"),
+                "duration_ms": df_tracks["ms_played"].apply(_clean_ms)
+                if "ms_played" in df_tracks.columns
+                else None,
+                "conn_country": df_tracks.get("conn_country"),
+                "ip_addr": df_tracks.get("ip_addr"),
+                "reason_start": df_tracks.get("reason_start"),
+                "reason_end": df_tracks.get("reason_end"),
+                "shuffle": df_tracks.get("shuffle"),
+                "skipped": df_tracks.get("skipped"),
+                "offline": df_tracks.get("offline"),
+                "offline_timestamp": df_tracks.get("offline_timestamp").apply(_to_timestamp)
+                if "offline_timestamp" in df_tracks.columns
+                else None,
+                "incognito_mode": df_tracks.get("incognito_mode"),
+            }
+        )
+
+    # Connect to DuckDB
+    db_path = str(db_path)
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute("BEGIN TRANSACTION;")
+        # Ensure user exists
+        _ensure_user(conn, user_id=user_id)
+
+        inserted_tracks = 0
+        existing_tracks = 0
+        inserted_plays = 0
+        deduped_plays = 0
+
+        # Bulk upsert tracks using anti-join
+        if not tracks_df.empty:
+            conn.register(
+                "to_tracks", tracks_df[["track_id", "spotify_track_id_only", "track_name"]]
+            )
+            inserted_tracks = conn.execute(
+                """
+                SELECT COUNT(*) FROM to_tracks t
+                ANTI JOIN dim_tracks d ON d.track_spotify_id = t.spotify_track_id_only
+                """
+            ).fetchone()[0]
+            existing_tracks = int(len(tracks_df) - inserted_tracks)
+            conn.execute(
+                """
+                INSERT INTO dim_tracks (track_id, track_spotify_id, track_name, album_id, duration_ms, explicit)
+                SELECT t.track_id, t.spotify_track_id_only, t.track_name, NULL, NULL, NULL
+                FROM to_tracks t
+                ANTI JOIN dim_tracks d ON d.track_spotify_id = t.spotify_track_id_only
+                """
+            )
+
+        # Bulk insert plays using anti-join on dedupe key
+        if not plays_df.empty:
+            conn.register("df_plays", plays_df)
+            inserted_plays = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM df_plays p
+                ANTI JOIN fact_plays f
+                  ON f.user_id = p.user_id AND f.track_id = p.track_id AND f.played_at = p.played_at
+                """
+            ).fetchone()[0]
+            deduped_plays = int(len(plays_df) - inserted_plays)
+
+            conn.execute(
+                """
+                INSERT INTO fact_plays (
+                    play_id,
+                    user_id,
+                    track_id,
+                    played_at,
+                    context_type,
+                    context_id,
+                    device_type,
+                    duration_ms,
+                    conn_country,
+                    ip_addr,
+                    reason_start,
+                    reason_end,
+                    shuffle,
+                    skipped,
+                    offline,
+                    offline_timestamp,
+                    incognito_mode
+                )
+                SELECT
+                    p.play_id,
+                    p.user_id,
+                    p.track_id,
+                    p.played_at,
+                    NULL,
+                    NULL,
+                    p.device_type,
+                    p.duration_ms,
+                    p.conn_country,
+                    p.ip_addr,
+                    p.reason_start,
+                    p.reason_end,
+                    p.shuffle,
+                    p.skipped,
+                    p.offline,
+                    p.offline_timestamp,
+                    p.incognito_mode
+                FROM df_plays p
+                ANTI JOIN fact_plays f
+                  ON f.user_id = p.user_id AND f.track_id = p.track_id AND f.played_at = p.played_at
+                """
+            )
+
+        conn.execute("COMMIT;")
+        return IngestResult(
+            inserted_plays=inserted_plays,
+            deduped_plays=deduped_plays,
+            inserted_tracks=inserted_tracks,
+            existing_tracks=existing_tracks,
+        )
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "IngestResult",
+    "load_history_into_fact_plays",
+]


### PR DESCRIPTION
Load the metadata into the duckdb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a comprehensive analytics database schema (tracks, artists, albums, genres, moods, plays) with per-user daily/monthly rollups.
  - Introduced a CLI (bsw) with commands to ingest Spotify history and enrich track metadata (ISRC, duration, explicit).
  - Enabled cached Spotify API lookups and bulk metadata backfill for faster, reliable enrichment.
  - Included seed users for quick start.

- Documentation
  - Added a detailed migration and data-flow guide outlining sources, normalization, and rollup calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->