### PR TITLE
Switch to Mantine dark mode

### DIFF
--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -167,15 +167,7 @@ body {
     gap: 10px;
 }
 
-.theme-toggle-label {
-    font-size: 1.5em;
-    margin: 0;
-    cursor: pointer;
-}
-
-.theme-toggle-switch {
-    margin: 0;
-}
+/* Removed legacy Bootstrap toggle label/switch styles */
 
 /* Dark theme styles */
 .dark-theme {

--- a/dashboard/callbacks/callbacks.py
+++ b/dashboard/callbacks/callbacks.py
@@ -1418,14 +1418,13 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
 
     @app.callback(
         [
-            Output("theme-toggle", "value"),
+            Output("theme-toggle", "checked"),
             Output("app-container", "className"),
-            Output("theme-icon", "children"),
             Output("theme-store", "data"),
         ],
         [
             Input("theme-store", "data"),
-            Input("theme-toggle", "value"),
+            Input("theme-toggle", "checked"),
         ],
         prevent_initial_call=False,
     )
@@ -1462,10 +1461,9 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                 is_dark = False
 
         theme_class = "dark-theme" if is_dark else ""
-        icon = "☀️" if is_dark else "🌙"
         theme_store_data = {"dark": is_dark}
 
-        return is_dark, theme_class, icon, theme_store_data
+        return is_dark, theme_class, theme_store_data
 
     # Clientside restyle-only callbacks to avoid server roundtrips
     app.clientside_callback(

--- a/dashboard/layouts/layouts.py
+++ b/dashboard/layouts/layouts.py
@@ -1,4 +1,5 @@
 import dash_bootstrap_components as dbc
+import dash_mantine_components as dmc  # type: ignore
 import pandas as pd
 from dash import dcc, html
 from dash.development.base_component import Component
@@ -63,16 +64,16 @@ def create_layout(df: pd.DataFrame) -> Component:
                                         ),
                                         html.Div(
                                             [
-                                                html.Label(
-                                                    "🌙",
-                                                    className="theme-toggle-label",
-                                                    id="theme-icon",
-                                                    title="Toggle dark mode",
-                                                ),
-                                                dbc.Switch(
+                                                dmc.Switch(
                                                     id="theme-toggle",
-                                                    value=False,
+                                                    checked=False,
+                                                    size="md",
+                                                    color="green",
+                                                    onLabel="☀️",
+                                                    offLabel="🌙",
                                                     className="theme-toggle-switch",
+                                                    persistence=True,
+                                                    persistence_type="local",
                                                 ),
                                             ],
                                             className="theme-toggle-container",


### PR DESCRIPTION
Switch to Mantine dark mode for simpler implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upgraded theme toggle to a modern switch with clearer labels and visuals.
  - Theme preference now persists across sessions (saved locally).

- Refactor
  - Simplified theme toggle behavior and state handling.
  - Removed the separate theme icon next to the toggle.

- Style
  - Cleaned up legacy toggle-related CSS to reduce clutter and improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->