### PR TITLE
Add-social-tab

### DIFF
--- a/dashboard/callbacks/callbacks.py
+++ b/dashboard/callbacks/callbacks.py
@@ -276,6 +276,14 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
             return not is_open
         return is_open
 
+    # Disable global single-user selector on Social tab
+    @app.callback(
+        Output("user-id-dropdown", "disabled"),
+        Input("main-tabs", "value"),
+    )
+    def disable_user_dropdown_on_social(tab_value: str):
+        return tab_value == "social"
+
     # ----------------------------------------------------------------------------
     # Server-side dropdown search (artists/albums/tracks) to reduce payload size
     # ----------------------------------------------------------------------------
@@ -562,6 +570,71 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
         # Otherwise, treat as manual change and set preset to custom
         return "custom", "manual"
 
+    # --- Social tab date-range controls (independent IDs) ---
+
+    @app.callback(
+        Output("social-date-range-mc", "value", allow_duplicate=True),
+        Output("social-date-range-source", "data", allow_duplicate=True),
+        Input("social-reset-date-range", "n_clicks"),
+        State("social-users-dropdown", "value"),
+        prevent_initial_call=True,
+    )
+    def social_reset_date_range(n_clicks: int, users_selected):
+        if not n_clicks:
+            raise PreventUpdate
+        df_sel = df
+        if users_selected:
+            df_sel = df[df.get("user_id").isin(users_selected)]
+            if df_sel.empty:
+                df_sel = df
+        min_ts = df_sel["ts"].min()
+        max_ts = df_sel["ts"].max()
+        start = datetime(min_ts.year, min_ts.month, min_ts.day)
+        end = datetime(max_ts.year, max_ts.month, max_ts.day)
+        return [start, end], "reset"
+
+    @app.callback(
+        Output("social-date-range-mc", "value", allow_duplicate=True),
+        Output("social-date-range-source", "data", allow_duplicate=True),
+        Input("social-date-range-preset", "value"),
+        State("social-users-dropdown", "value"),
+        prevent_initial_call=True,
+    )
+    def social_apply_date_preset(preset: str, users_selected):
+        if not preset or preset == "custom":
+            raise PreventUpdate
+        df_sel = df
+        if users_selected:
+            df_sel = df[df.get("user_id").isin(users_selected)]
+            if df_sel.empty:
+                df_sel = df
+        min_ts = df_sel["ts"].min()
+        max_ts = df_sel["ts"].max()
+        end = datetime(max_ts.year, max_ts.month, max_ts.day)
+        if preset == "60d":
+            start = end - timedelta(days=60)
+        elif preset == "ytd":
+            start = datetime(end.year, 1, 1)
+        elif preset == "all":
+            start = datetime(min_ts.year, min_ts.month, min_ts.day)
+        else:
+            raise PreventUpdate
+        return [start, end], "preset"
+
+    @app.callback(
+        Output("social-date-range-preset", "value"),
+        Output("social-date-range-source", "data", allow_duplicate=True),
+        Input("social-date-range-mc", "value"),
+        State("social-date-range-source", "data"),
+        prevent_initial_call=True,
+    )
+    def social_set_preset_on_date_change(_value, source):
+        if not _value or len(_value) != 2:
+            raise PreventUpdate
+        if source in {"preset", "reset"}:
+            return dash.no_update, None
+        return "custom", "manual"
+
     # --- Wrapped Tab (Tab 1): Build a single data store, then per-figure callbacks ---
 
     @app.callback(
@@ -739,9 +812,9 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
         Output("social-data", "data"),
         [
             Input("social-users-dropdown", "value"),
-            Input("social-date-range", "start_date"),
-            Input("social-date-range", "end_date"),
+            Input("social-date-range-mc", "value"),
             Input("social-mode", "value"),
+            Input("social-genre-hide-level0-radio", "value"),
             # Global filters respected
             Input("excluded-artists-filter-dropdown", "value"),
             Input("excluded-genres-filter-dropdown", "value"),
@@ -753,9 +826,9 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
     )
     def compute_social_data(
         users,
-        start_date,
-        end_date,
+        date_range_value,
         mode,
+        hide_parent_genres,
         excluded_artists,
         excluded_genres,
         excluded_albums,
@@ -773,10 +846,17 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
         if len(users) > 3:
             users = users[:3]
 
+        # Parse date range
+        start_date = None
+        end_date = None
+        if date_range_value and isinstance(date_range_value, list) and len(date_range_value) == 2:
+            start_date = pd.to_datetime(date_range_value[0]) if date_range_value[0] else None
+            end_date = pd.to_datetime(date_range_value[1]) if date_range_value[1] else None
+
         # Compute with DuckDB backend
         con = get_db_connection()
         try:
-            out = compute_social_regions(
+            kwargs = dict(
                 con=con,
                 users=users,
                 start=pd.to_datetime(start_date) if start_date else None,
@@ -790,10 +870,23 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                 excluded_genres=excluded_genres,
                 limit_per_region=10,
             )
+            if (mode or "tracks") == "genres":
+                kwargs["hide_parent_genres"] = bool(hide_parent_genres)
+            out = compute_social_regions(**kwargs)
         finally:
             with contextlib.suppress(Exception):
                 con.close()
         return out
+
+    # Show/hide Social genre parent toggle depending on mode
+    @app.callback(
+        Output("social-genre-hide-level0-container", "style"),
+        Input("social-mode", "value"),
+    )
+    def toggle_social_genre_parent_visibility(mode):
+        if mode == "genres":
+            return {"display": "block"}
+        return {"display": "none"}
 
     @app.callback(
         Output("social-venn-graph", "figure"),
@@ -811,10 +904,21 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
         if not data or data.get("error"):
             msg = data.get("error") if data else "Select 2–3 users to compare."
             return {"data": [], "layout": theme}, html.Div(msg)
+        # Warn and block when any selected user has zero plays within filters
+        user_counts = data.get("user_counts", {})
+        if any(user_counts.get(str(u), 0) == 0 for u in data.get("users", [])):
+            return {"data": [], "layout": theme}, html.Div(
+                "One or more selected users have no plays in range; adjust filters or deselect."
+            )
 
         users = data.get("users", [])
         regions = data.get("regions", {})
         totals = data.get("totals", {})
+        user_labels = data.get("user_labels", {})
+
+        def lbl(u):
+            return user_labels.get(str(u), str(u))
+
         # Build a minimalist Venn with circles and counts in annotations
         fig = go.Figure()
         # Merge axis visibility overrides with theme without duplicating kwargs
@@ -843,25 +947,138 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
         hover_traces = []
         if len(users) == 2:
             # Place two circles with overlap
-            _add_circle(0.0, 0.0, 1.2, "#1DB954", str(users[0]))
-            _add_circle(1.2, 0.0, 1.2, "#0f7a35", str(users[1]))
+            _add_circle(0.0, 0.0, 1.2, "#1DB954", lbl(users[0]))
+            _add_circle(1.2, 0.0, 1.2, "#0f7a35", lbl(users[1]))
             # Put intersection count
             inter_key = f"{users[0]}_{users[1]}"
             inter_count = len(regions.get(inter_key, []))
             ann.append({"x": 0.6, "y": 0.0, "text": f"∩: {inter_count}", "showarrow": False})
             fig.update_xaxes(range=[-1.6, 2.8])
             fig.update_yaxes(range=[-1.6, 1.8])
+
             # Hover/select points for regions
             def _tooltip_for(key: str, title: str) -> str:
                 items = regions.get(key, [])
                 lines = [title, f"Total: {totals.get(key, len(items))}"]
+                # Include per-user ranks and counts and joint rank for each item
                 for it in items[:10]:
-                    lines.append(f"- {it['name']}")
+                    parts = []
+                    # joint rank rounded
+                    try:
+                        jr = it.get("joint_rank")
+                        if jr is not None:
+                            parts.append(f"JR {round(float(jr), 2)}")
+                    except Exception:
+                        pass
+                    for u in users:
+                        if u in it.get("ranks", {}):
+                            rnk = it["ranks"].get(u)
+                            cnt = it["counts"].get(u, 0)
+                            parts.append(f"{lbl(u)}: r{rnk}/{cnt}")
+                    lines.append("- " + it["name"] + (" — " + "; ".join(parts) if parts else ""))
                 if totals.get(key, len(items)) > len(items):
                     lines.append("+ more not shown")
                 return "<br>".join(lines)
 
+            # Filled circle polygons for larger hover/click target areas
+            import numpy as _np
+
+            def circle_poly(xc, yc, r, steps=100):
+                t = _np.linspace(0, 2 * _np.pi, steps)
+                return (xc + r * _np.cos(t), yc + r * _np.sin(t))
+
+            # Lens polygon for intersection
+            def lens_poly(xc1, yc1, xc2, yc2, r, steps=60):
+                import math as _m
+
+                dx = xc2 - xc1
+                dy = yc2 - yc1
+                d = _m.hypot(dx, dy)
+                if d == 0 or d > 2 * r:
+                    return ([], [])
+                # angles for circle1
+                ax = dx / 2
+                ay = dy / 2
+                # intersection points angles relative to circle1
+                # vector to intersection points from midpoint perpendicular
+                # For equal radii and our layout dy=0
+                # general case formula
+                angle_mid = _m.atan2(ay, ax)
+                h = _m.sqrt(max(r * r - (d / 2) * (d / 2), 0.0))
+                # unit perpendicular vector
+                ux = -dy / d if d != 0 else 0
+                uy = dx / d if d != 0 else 0
+                # intersection points
+                x1 = (xc1 + xc2) / 2 + ux * h
+                y1 = (yc1 + yc2) / 2 + uy * h
+                x2 = (xc1 + xc2) / 2 - ux * h
+                y2 = (yc1 + yc2) / 2 - uy * h
+                # angles on each circle
+                a1 = _m.atan2(y1 - yc1, x1 - xc1)
+                a2 = _m.atan2(y2 - yc1, x2 - xc1)
+                b1 = _m.atan2(y1 - yc2, x1 - xc2)
+                b2 = _m.atan2(y2 - yc2, x2 - xc2)
+
+                # sample arcs: circle1 from a1 to a2 (short way), circle2 from b2 to b1 (short way)
+                def arc(xc, yc, r, ang_start, ang_end, n):
+                    # go the shorter direction
+                    da = ang_end - ang_start
+                    while da <= -_m.pi:
+                        da += 2 * _m.pi
+                    while da > _m.pi:
+                        da -= 2 * _m.pi
+                    ts = [ang_start + da * i / (n - 1) for i in range(n)]
+                    return [xc + r * _m.cos(t) for t in ts], [yc + r * _m.sin(t) for t in ts]
+
+                xA, yA = arc(xc1, yc1, r, a1, a2, steps)
+                xB, yB = arc(xc2, yc2, r, b2, b1, steps)
+                return (xA + xB, yA + yB)
+
+            u1, u2 = users
+            x1, y1 = circle_poly(0.0, 0.0, 1.2)
+            x2, y2 = circle_poly(1.2, 0.0, 1.2)
+            xl, yl = lens_poly(0.0, 0.0, 1.2, 0.0, 1.2)
+
             hover_traces = [
+                {
+                    "type": "scatter",
+                    "x": x1,
+                    "y": y1,
+                    "mode": "lines",
+                    "fill": "toself",
+                    "opacity": 0.08,
+                    "line": {"color": "#1DB954"},
+                    "hovertemplate": _tooltip_for(f"{u1}_only", f"{lbl(u1)} only")
+                    + "<extra></extra>",
+                    "customdata": [f"{u1}_only"] * len(x1),
+                    "name": f"{lbl(u1)} only",
+                },
+                {
+                    "type": "scatter",
+                    "x": x2,
+                    "y": y2,
+                    "mode": "lines",
+                    "fill": "toself",
+                    "opacity": 0.08,
+                    "line": {"color": "#0f7a35"},
+                    "hovertemplate": _tooltip_for(f"{u2}_only", f"{lbl(u2)} only")
+                    + "<extra></extra>",
+                    "customdata": [f"{u2}_only"] * len(x2),
+                    "name": f"{lbl(u2)} only",
+                },
+                {
+                    "type": "scatter",
+                    "x": xl,
+                    "y": yl,
+                    "mode": "lines",
+                    "fill": "toself",
+                    "opacity": 0.14,
+                    "line": {"color": "#11803b"},
+                    "hovertemplate": _tooltip_for(inter_key, f"{lbl(u1)} ∩ {lbl(u2)}")
+                    + "<extra></extra>",
+                    "customdata": [inter_key] * len(xl),
+                    "name": f"{lbl(u1)} ∩ {lbl(u2)}",
+                },
                 {
                     "type": "scatter",
                     "x": [-0.6],
@@ -870,10 +1087,14 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 30 if selected_region == f"{users[0]}_only" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2 if selected_region == f"{users[0]}_only" else 1, "color": "#1DB954"},
+                        "line": {
+                            "width": 2 if selected_region == f"{users[0]}_only" else 1,
+                            "color": "#1DB954",
+                        },
                     },
-                    "name": f"{users[0]} only",
-                    "hovertemplate": _tooltip_for(f"{users[0]}_only", f"{users[0]} only") + "<extra></extra>",
+                    "name": f"{lbl(users[0])} only",
+                    "hovertemplate": _tooltip_for(f"{users[0]}_only", f"{lbl(users[0])} only")
+                    + "<extra></extra>",
                     "customdata": [f"{users[0]}_only"],
                 },
                 {
@@ -884,10 +1105,14 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 30 if selected_region == f"{users[0]}_{users[1]}" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2 if selected_region == f"{users[0]}_{users[1]}" else 1, "color": "#11803b"},
+                        "line": {
+                            "width": 2 if selected_region == f"{users[0]}_{users[1]}" else 1,
+                            "color": "#11803b",
+                        },
                     },
-                    "name": f"{users[0]} ∩ {users[1]}",
-                    "hovertemplate": _tooltip_for(inter_key, f"{users[0]} ∩ {users[1]}") + "<extra></extra>",
+                    "name": f"{lbl(users[0])} ∩ {lbl(users[1])}",
+                    "hovertemplate": _tooltip_for(inter_key, f"{lbl(users[0])} ∩ {lbl(users[1])}")
+                    + "<extra></extra>",
                     "customdata": [inter_key],
                 },
                 {
@@ -898,33 +1123,105 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 30 if selected_region == f"{users[1]}_only" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2 if selected_region == f"{users[1]}_only" else 1, "color": "#0f7a35"},
+                        "line": {
+                            "width": 2 if selected_region == f"{users[1]}_only" else 1,
+                            "color": "#0f7a35",
+                        },
                     },
-                    "name": f"{users[1]} only",
-                    "hovertemplate": _tooltip_for(f"{users[1]}_only", f"{users[1]} only") + "<extra></extra>",
+                    "name": f"{lbl(users[1])} only",
+                    "hovertemplate": _tooltip_for(f"{users[1]}_only", f"{lbl(users[1])} only")
+                    + "<extra></extra>",
                     "customdata": [f"{users[1]}_only"],
                 },
             ]
         else:
             # Three circles positioned in a triangle
-            _add_circle(0.0, 0.6, 1.2, "#1DB954", str(users[0]))
-            _add_circle(1.4, 0.6, 1.2, "#0f7a35", str(users[1]))
-            _add_circle(0.7, -0.6, 1.2, "#169c48", str(users[2]))
+            _add_circle(0.0, 0.6, 1.2, "#1DB954", lbl(users[0]))
+            _add_circle(1.4, 0.6, 1.2, "#0f7a35", lbl(users[1]))
+            _add_circle(0.7, -0.6, 1.2, "#169c48", lbl(users[2]))
             inter_key = f"{users[0]}_{users[1]}_{users[2]}"
             inter_count = len(regions.get(inter_key, []))
             ann.append({"x": 0.7, "y": 0.2, "text": f"∩3: {inter_count}", "showarrow": False})
             fig.update_xaxes(range=[-1.6, 3.0])
             fig.update_yaxes(range=[-1.8, 2.0])
+
             def _tooltip_for(key: str, title: str) -> str:
                 items = regions.get(key, [])
                 lines = [title, f"Total: {totals.get(key, len(items))}"]
                 for it in items[:10]:
-                    lines.append(f"- {it['name']}")
+                    parts = []
+                    try:
+                        jr = it.get("joint_rank")
+                        if jr is not None:
+                            parts.append(f"JR {round(float(jr), 2)}")
+                    except Exception:
+                        pass
+                    for u in users:
+                        if u in it.get("ranks", {}):
+                            rnk = it["ranks"].get(u)
+                            cnt = it["counts"].get(u, 0)
+                            parts.append(f"{u}: r{rnk}/{cnt}")
+                    lines.append("- " + it["name"] + (" — " + "; ".join(parts) if parts else ""))
                 if totals.get(key, len(items)) > len(items):
                     lines.append("+ more not shown")
                 return "<br>".join(lines)
 
             u1, u2, u3 = users
+            # Fill each user's circle to enlarge hover/click area for only-regions
+            import numpy as _np
+
+            def circle_poly(xc, yc, r, steps=100):
+                t = _np.linspace(0, 2 * _np.pi, steps)
+                return (xc + r * _np.cos(t), yc + r * _np.sin(t))
+
+            x1, y1 = circle_poly(0.0, 0.6, 1.2)
+            x2, y2 = circle_poly(1.4, 0.6, 1.2)
+            x3, y3 = circle_poly(0.7, -0.6, 1.2)
+            fig.add_trace(
+                {
+                    "type": "scatter",
+                    "x": x1,
+                    "y": y1,
+                    "mode": "lines",
+                    "fill": "toself",
+                    "opacity": 0.08,
+                    "line": {"color": "#1DB954"},
+                    "hovertemplate": _tooltip_for(f"{u1}_only", f"{lbl(u1)} only")
+                    + "<extra></extra>",
+                    "customdata": [f"{u1}_only"] * len(x1),
+                    "name": f"{lbl(u1)} only",
+                }
+            )
+            fig.add_trace(
+                {
+                    "type": "scatter",
+                    "x": x2,
+                    "y": y2,
+                    "mode": "lines",
+                    "fill": "toself",
+                    "opacity": 0.08,
+                    "line": {"color": "#0f7a35"},
+                    "hovertemplate": _tooltip_for(f"{u2}_only", f"{lbl(u2)} only")
+                    + "<extra></extra>",
+                    "customdata": [f"{u2}_only"] * len(x2),
+                    "name": f"{lbl(u2)} only",
+                }
+            )
+            fig.add_trace(
+                {
+                    "type": "scatter",
+                    "x": x3,
+                    "y": y3,
+                    "mode": "lines",
+                    "fill": "toself",
+                    "opacity": 0.08,
+                    "line": {"color": "#169c48"},
+                    "hovertemplate": _tooltip_for(f"{u3}_only", f"{lbl(u3)} only")
+                    + "<extra></extra>",
+                    "customdata": [f"{u3}_only"] * len(x3),
+                    "name": f"{lbl(u3)} only",
+                }
+            )
             hover_traces = [
                 # only regions
                 {
@@ -932,7 +1229,11 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "x": [-0.6],
                     "y": [0.8],
                     "mode": "markers",
-                    "marker": {"size": 28 if selected_region == f"{u1}_only" else 20, "color": "rgba(0,0,0,0)", "line": {"width": 2, "color": "#1DB954"}},
+                    "marker": {
+                        "size": 28 if selected_region == f"{u1}_only" else 20,
+                        "color": "rgba(0,0,0,0)",
+                        "line": {"width": 2, "color": "#1DB954"},
+                    },
                     "name": f"{u1} only",
                     "hovertemplate": _tooltip_for(f"{u1}_only", f"{u1} only") + "<extra></extra>",
                     "customdata": [f"{u1}_only"],
@@ -942,7 +1243,11 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "x": [2.0],
                     "y": [0.8],
                     "mode": "markers",
-                    "marker": {"size": 28 if selected_region == f"{u2}_only" else 20, "color": "rgba(0,0,0,0)", "line": {"width": 2, "color": "#0f7a35"}},
+                    "marker": {
+                        "size": 28 if selected_region == f"{u2}_only" else 20,
+                        "color": "rgba(0,0,0,0)",
+                        "line": {"width": 2, "color": "#0f7a35"},
+                    },
                     "name": f"{u2} only",
                     "hovertemplate": _tooltip_for(f"{u2}_only", f"{u2} only") + "<extra></extra>",
                     "customdata": [f"{u2}_only"],
@@ -952,7 +1257,11 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "x": [0.7],
                     "y": [-1.5],
                     "mode": "markers",
-                    "marker": {"size": 28 if selected_region == f"{u3}_only" else 20, "color": "rgba(0,0,0,0)", "line": {"width": 2, "color": "#169c48"}},
+                    "marker": {
+                        "size": 28 if selected_region == f"{u3}_only" else 20,
+                        "color": "rgba(0,0,0,0)",
+                        "line": {"width": 2, "color": "#169c48"},
+                    },
                     "name": f"{u3} only",
                     "hovertemplate": _tooltip_for(f"{u3}_only", f"{u3} only") + "<extra></extra>",
                     "customdata": [f"{u3}_only"],
@@ -963,9 +1272,14 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "x": [0.7],
                     "y": [1.2],
                     "mode": "markers",
-                    "marker": {"size": 28 if selected_region == f"{u1}_{u2}" else 20, "color": "rgba(0,0,0,0)", "line": {"width": 2, "color": "#11803b"}},
-                    "name": f"{u1} ∩ {u2}",
-                    "hovertemplate": _tooltip_for(f"{u1}_{u2}", f"{u1} ∩ {u2}") + "<extra></extra>",
+                    "marker": {
+                        "size": 28 if selected_region == f"{u1}_{u2}" else 20,
+                        "color": "rgba(0,0,0,0)",
+                        "line": {"width": 2, "color": "#11803b"},
+                    },
+                    "name": f"{lbl(u1)} ∩ {lbl(u2)}",
+                    "hovertemplate": _tooltip_for(f"{u1}_{u2}", f"{lbl(u1)} ∩ {lbl(u2)}")
+                    + "<extra></extra>",
                     "customdata": [f"{u1}_{u2}"],
                 },
                 {
@@ -973,9 +1287,14 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "x": [0.2],
                     "y": [0.0],
                     "mode": "markers",
-                    "marker": {"size": 28 if selected_region == f"{u1}_{u3}" else 20, "color": "rgba(0,0,0,0)", "line": {"width": 2, "color": "#11803b"}},
-                    "name": f"{u1} ∩ {u3}",
-                    "hovertemplate": _tooltip_for(f"{u1}_{u3}", f"{u1} ∩ {u3}") + "<extra></extra>",
+                    "marker": {
+                        "size": 28 if selected_region == f"{u1}_{u3}" else 20,
+                        "color": "rgba(0,0,0,0)",
+                        "line": {"width": 2, "color": "#11803b"},
+                    },
+                    "name": f"{lbl(u1)} ∩ {lbl(u3)}",
+                    "hovertemplate": _tooltip_for(f"{u1}_{u3}", f"{lbl(u1)} ∩ {lbl(u3)}")
+                    + "<extra></extra>",
                     "customdata": [f"{u1}_{u3}"],
                 },
                 {
@@ -983,9 +1302,14 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "x": [1.2],
                     "y": [0.0],
                     "mode": "markers",
-                    "marker": {"size": 28 if selected_region == f"{u2}_{u3}" else 20, "color": "rgba(0,0,0,0)", "line": {"width": 2, "color": "#11803b"}},
-                    "name": f"{u2} ∩ {u3}",
-                    "hovertemplate": _tooltip_for(f"{u2}_{u3}", f"{u2} ∩ {u3}") + "<extra></extra>",
+                    "marker": {
+                        "size": 28 if selected_region == f"{u2}_{u3}" else 20,
+                        "color": "rgba(0,0,0,0)",
+                        "line": {"width": 2, "color": "#11803b"},
+                    },
+                    "name": f"{lbl(u2)} ∩ {lbl(u3)}",
+                    "hovertemplate": _tooltip_for(f"{u2}_{u3}", f"{lbl(u2)} ∩ {lbl(u3)}")
+                    + "<extra></extra>",
                     "customdata": [f"{u2}_{u3}"],
                 },
                 # 3-way
@@ -994,9 +1318,17 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "x": [0.7],
                     "y": [0.2],
                     "mode": "markers",
-                    "marker": {"size": 32 if selected_region == inter_key else 22, "color": "rgba(0,0,0,0)", "line": {"width": 3 if selected_region == inter_key else 2, "color": "#0f7a35"}},
-                    "name": f"{u1} ∩ {u2} ∩ {u3}",
-                    "hovertemplate": _tooltip_for(inter_key, f"{u1} ∩ {u2} ∩ {u3}") + "<extra></extra>",
+                    "marker": {
+                        "size": 32 if selected_region == inter_key else 22,
+                        "color": "rgba(0,0,0,0)",
+                        "line": {
+                            "width": 3 if selected_region == inter_key else 2,
+                            "color": "#0f7a35",
+                        },
+                    },
+                    "name": f"{lbl(u1)} ∩ {lbl(u2)} ∩ {lbl(u3)}",
+                    "hovertemplate": _tooltip_for(inter_key, f"{lbl(u1)} ∩ {lbl(u2)} ∩ {lbl(u3)}")
+                    + "<extra></extra>",
                     "customdata": [inter_key],
                 },
             ]
@@ -1041,18 +1373,9 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                 blocks.append(_region_block(title, regions.get(key, []), totals.get(key)))
             else:
                 blocks.append(
-                    _region_block(
-                        f"{u1} only", regions.get(f"{u1}_only", []), totals.get(f"{u1}_only")
-                    )
-                )
-                blocks.append(
-                    _region_block(
-                        f"{u1} ∩ {u2}", regions.get(f"{u1}_{u2}", []), totals.get(f"{u1}_{u2}")
-                    )
-                )
-                blocks.append(
-                    _region_block(
-                        f"{u2} only", regions.get(f"{u2}_only", []), totals.get(f"{u2}_only")
+                    html.Div(
+                        [html.Div("Click a region to show details", className="card-subtitle")],
+                        className="card",
                     )
                 )
         else:
@@ -1075,16 +1398,12 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     title = f"{u1} ∩ {u2} ∩ {u3}"
                 blocks.append(_region_block(title, regions.get(key, []), totals.get(key)))
             else:
-                for key, title in [
-                    (f"{u1}_only", f"{u1} only"),
-                    (f"{u2}_only", f"{u2} only"),
-                    (f"{u3}_only", f"{u3} only"),
-                    (f"{u1}_{u2}", f"{u1} ∩ {u2}"),
-                    (f"{u1}_{u3}", f"{u1} ∩ {u3}"),
-                    (f"{u2}_{u3}", f"{u2} ∩ {u3}"),
-                    (f"{u1}_{u2}_{u3}", f"{u1} ∩ {u2} ∩ {u3}"),
-                ]:
-                    blocks.append(_region_block(title, regions.get(key, []), totals.get(key)))
+                blocks.append(
+                    html.Div(
+                        [html.Div("Click a region to show details", className="card-subtitle")],
+                        className="card",
+                    )
+                )
 
         return fig, html.Div(blocks, className="graph-container")
 

--- a/dashboard/callbacks/callbacks.py
+++ b/dashboard/callbacks/callbacks.py
@@ -856,20 +856,20 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
         # Compute with DuckDB backend
         con = get_db_connection()
         try:
-            kwargs = dict(
-                con=con,
-                users=users,
-                start=pd.to_datetime(start_date) if start_date else None,
-                end=pd.to_datetime(end_date) if end_date else None,
-                mode=mode or "tracks",
-                exclude_december=bool(exclude_december),
-                remove_incognito=bool(remove_incognito),
-                excluded_tracks=excluded_tracks,
-                excluded_artists=excluded_artists,
-                excluded_albums=excluded_albums,
-                excluded_genres=excluded_genres,
-                limit_per_region=10,
-            )
+            kwargs = {
+                "con": con,
+                "users": users,
+                "start": pd.to_datetime(start_date) if start_date else None,
+                "end": pd.to_datetime(end_date) if end_date else None,
+                "mode": mode or "tracks",
+                "exclude_december": bool(exclude_december),
+                "remove_incognito": bool(remove_incognito),
+                "excluded_tracks": excluded_tracks,
+                "excluded_artists": excluded_artists,
+                "excluded_albums": excluded_albums,
+                "excluded_genres": excluded_genres,
+                "limit_per_region": 10,
+            }
             if (mode or "tracks") == "genres":
                 kwargs["hide_parent_genres"] = bool(hide_parent_genres)
             out = compute_social_regions(**kwargs)
@@ -997,13 +997,10 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                 if d == 0 or d > 2 * r:
                     return ([], [])
                 # angles for circle1
-                ax = dx / 2
-                ay = dy / 2
                 # intersection points angles relative to circle1
                 # vector to intersection points from midpoint perpendicular
                 # For equal radii and our layout dy=0
                 # general case formula
-                angle_mid = _m.atan2(ay, ax)
                 h = _m.sqrt(max(r * r - (d / 2) * (d / 2), 0.0))
                 # unit perpendicular vector
                 ux = -dy / d if d != 0 else 0
@@ -1078,60 +1075,6 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     + "<extra></extra>",
                     "customdata": [inter_key] * len(xl),
                     "name": f"{lbl(u1)} ∩ {lbl(u2)}",
-                },
-                {
-                    "type": "scatter",
-                    "x": [-0.6],
-                    "y": [0.0],
-                    "mode": "markers",
-                    "marker": {
-                        "size": 30 if selected_region == f"{users[0]}_only" else 20,
-                        "color": "rgba(0,0,0,0)",
-                        "line": {
-                            "width": 2 if selected_region == f"{users[0]}_only" else 1,
-                            "color": "#1DB954",
-                        },
-                    },
-                    "name": f"{lbl(users[0])} only",
-                    "hovertemplate": _tooltip_for(f"{users[0]}_only", f"{lbl(users[0])} only")
-                    + "<extra></extra>",
-                    "customdata": [f"{users[0]}_only"],
-                },
-                {
-                    "type": "scatter",
-                    "x": [0.6],
-                    "y": [0.0],
-                    "mode": "markers",
-                    "marker": {
-                        "size": 30 if selected_region == f"{users[0]}_{users[1]}" else 20,
-                        "color": "rgba(0,0,0,0)",
-                        "line": {
-                            "width": 2 if selected_region == f"{users[0]}_{users[1]}" else 1,
-                            "color": "#11803b",
-                        },
-                    },
-                    "name": f"{lbl(users[0])} ∩ {lbl(users[1])}",
-                    "hovertemplate": _tooltip_for(inter_key, f"{lbl(users[0])} ∩ {lbl(users[1])}")
-                    + "<extra></extra>",
-                    "customdata": [inter_key],
-                },
-                {
-                    "type": "scatter",
-                    "x": [1.8],
-                    "y": [0.0],
-                    "mode": "markers",
-                    "marker": {
-                        "size": 30 if selected_region == f"{users[1]}_only" else 20,
-                        "color": "rgba(0,0,0,0)",
-                        "line": {
-                            "width": 2 if selected_region == f"{users[1]}_only" else 1,
-                            "color": "#0f7a35",
-                        },
-                    },
-                    "name": f"{lbl(users[1])} only",
-                    "hovertemplate": _tooltip_for(f"{users[1]}_only", f"{lbl(users[1])} only")
-                    + "<extra></extra>",
-                    "customdata": [f"{users[1]}_only"],
                 },
             ]
         else:
@@ -1232,7 +1175,7 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 28 if selected_region == f"{u1}_only" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2, "color": "#1DB954"},
+                        "line": {"width": 0, "color": "rgba(0,0,0,0)"},
                     },
                     "name": f"{u1} only",
                     "hovertemplate": _tooltip_for(f"{u1}_only", f"{u1} only") + "<extra></extra>",
@@ -1246,7 +1189,7 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 28 if selected_region == f"{u2}_only" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2, "color": "#0f7a35"},
+                        "line": {"width": 0, "color": "rgba(0,0,0,0)"},
                     },
                     "name": f"{u2} only",
                     "hovertemplate": _tooltip_for(f"{u2}_only", f"{u2} only") + "<extra></extra>",
@@ -1260,7 +1203,7 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 28 if selected_region == f"{u3}_only" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2, "color": "#169c48"},
+                        "line": {"width": 0, "color": "rgba(0,0,0,0)"},
                     },
                     "name": f"{u3} only",
                     "hovertemplate": _tooltip_for(f"{u3}_only", f"{u3} only") + "<extra></extra>",
@@ -1275,7 +1218,7 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 28 if selected_region == f"{u1}_{u2}" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2, "color": "#11803b"},
+                        "line": {"width": 0, "color": "rgba(0,0,0,0)"},
                     },
                     "name": f"{lbl(u1)} ∩ {lbl(u2)}",
                     "hovertemplate": _tooltip_for(f"{u1}_{u2}", f"{lbl(u1)} ∩ {lbl(u2)}")
@@ -1290,7 +1233,7 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 28 if selected_region == f"{u1}_{u3}" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2, "color": "#11803b"},
+                        "line": {"width": 0, "color": "rgba(0,0,0,0)"},
                     },
                     "name": f"{lbl(u1)} ∩ {lbl(u3)}",
                     "hovertemplate": _tooltip_for(f"{u1}_{u3}", f"{lbl(u1)} ∩ {lbl(u3)}")
@@ -1305,7 +1248,7 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                     "marker": {
                         "size": 28 if selected_region == f"{u2}_{u3}" else 20,
                         "color": "rgba(0,0,0,0)",
-                        "line": {"width": 2, "color": "#11803b"},
+                        "line": {"width": 0, "color": "rgba(0,0,0,0)"},
                     },
                     "name": f"{lbl(u2)} ∩ {lbl(u3)}",
                     "hovertemplate": _tooltip_for(f"{u2}_{u3}", f"{lbl(u2)} ∩ {lbl(u3)}")
@@ -1322,8 +1265,8 @@ def register_callbacks(app: Dash, df: pd.DataFrame) -> None:
                         "size": 32 if selected_region == inter_key else 22,
                         "color": "rgba(0,0,0,0)",
                         "line": {
-                            "width": 3 if selected_region == inter_key else 2,
-                            "color": "#0f7a35",
+                            "width": 0,
+                            "color": "rgba(0,0,0,0)",
                         },
                     },
                     "name": f"{lbl(u1)} ∩ {lbl(u2)} ∩ {lbl(u3)}",

--- a/dashboard/components/filters.py
+++ b/dashboard/components/filters.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import dash_mantine_components as dmc  # type: ignore
 import pandas as pd
 from dash import dcc, html
@@ -255,10 +257,11 @@ def create_social_date_range_filter(df: pd.DataFrame) -> html.Div:
 
     Uses separate component IDs to avoid collisions with the Trends tab.
     """
-    min_ts = df["ts"].min()
-    max_ts = df["ts"].max()
-    start_date = min_ts.date() if hasattr(min_ts, "date") else min_ts
-    end_date = max_ts.date() if hasattr(max_ts, "date") else max_ts
+    coerced_ts = pd.to_datetime(df["ts"], errors="coerce")
+    min_ts = coerced_ts.min()
+    max_ts = coerced_ts.max()
+    start_date = date.today() if pd.isna(min_ts) else min_ts.date()
+    end_date = date.today() if pd.isna(max_ts) else max_ts.date()
 
     children: list = [html.Label("Select Date Range", className="filter-label")]
 

--- a/dashboard/components/filters.py
+++ b/dashboard/components/filters.py
@@ -250,6 +250,70 @@ def create_year_range_filter(df: pd.DataFrame) -> html.Div:
     return html.Div(children, className="filter-item")
 
 
+def create_social_date_range_filter(df: pd.DataFrame) -> html.Div:
+    """Create Social tab date range filter (Mantine + presets).
+
+    Uses separate component IDs to avoid collisions with the Trends tab.
+    """
+    min_ts = df["ts"].min()
+    max_ts = df["ts"].max()
+    start_date = min_ts.date() if hasattr(min_ts, "date") else min_ts
+    end_date = max_ts.date() if hasattr(max_ts, "date") else max_ts
+
+    children: list = [html.Label("Select Date Range", className="filter-label")]
+
+    children.append(
+        dmc.DatePickerInput(
+            id="social-date-range-mc",
+            type="range",
+            value=[start_date, end_date],
+            minDate=start_date,
+            maxDate=end_date,
+            allowSingleDateInRange=True,
+            numberOfColumns=2,
+            firstDayOfWeek=1,
+            size="sm",
+            variant="filled",
+            popoverProps={
+                "withinPortal": True,
+                "zIndex": 4000,
+                "position": "bottom-start",
+                "offset": 8,
+            },
+            persistence=True,
+            persistence_type="local",
+        )
+    )
+    children.append(
+        dmc.SegmentedControl(
+            id="social-date-range-preset",
+            data=[
+                {"label": "Last 60d", "value": "60d"},
+                {"label": "YTD", "value": "ytd"},
+                {"label": "All", "value": "all"},
+                {"label": "Custom", "value": "custom"},
+            ],
+            value="custom",
+            size="xs",
+            radius="xl",
+            persistence=True,
+            persistence_type="local",
+            style={"marginTop": "8px"},
+        )
+    )
+    children.append(
+        html.Button(
+            "Reset Date Range",
+            id="social-reset-date-range",
+            className="reset-button",
+            n_clicks=0,
+        )
+    )
+    children.append(dcc.Store(id="social-date-range-source", storage_type="memory"))
+
+    return html.Div(children, className="filter-item")
+
+
 def create_genre_trends_layout(_df: pd.DataFrame) -> html.Div:
     """Create the layout for the genre trends analysis section.
 

--- a/dashboard/layouts/layouts.py
+++ b/dashboard/layouts/layouts.py
@@ -357,6 +357,8 @@ def create_tab_social_layout(df: pd.DataFrame) -> Component:
             ),
             # Store for computed social data
             dcc.Store(id="social-data"),
+            # Store for selected region (to filter lists)
+            dcc.Store(id="social-selected-region"),
         ],
         className="container",
     )

--- a/dashboard/layouts/layouts.py
+++ b/dashboard/layouts/layouts.py
@@ -6,6 +6,7 @@ from dash.development.base_component import Component
 
 from dashboard.components.filters import (
     create_global_settings,
+    create_social_date_range_filter,
     create_trend_filters_section,
     create_wrapped_filters_section,
 )
@@ -137,20 +138,25 @@ def create_layout(df: pd.DataFrame) -> Component:
                     ),
                     # Main content tabs
                     dcc.Tabs(
-                        [
+                        id="main-tabs",
+                        value="wrapped",
+                        children=[
                             dcc.Tab(
                                 label="🎁 Wrapped",
+                                value="wrapped",
                                 children=[create_tab_one_layout(df)],
                             ),
                             dcc.Tab(
                                 label="📈 Trends",
+                                value="trends",
                                 children=[create_tab_two_layout(df)],
                             ),
                             dcc.Tab(
                                 label="👥 Social",
+                                value="social",
                                 children=[create_tab_social_layout(df)],
                             ),
-                        ]
+                        ],
                     ),
                 ],
                 id="app-container",
@@ -300,18 +306,7 @@ def create_tab_social_layout(df: pd.DataFrame) -> Component:
                         [
                             _create_social_user_selector(df),
                             # Local date range (independent of Trends tab)
-                            html.Div(
-                                [
-                                    html.Label("Select Date Range", className="filter-label"),
-                                    dcc.DatePickerRange(
-                                        id="social-date-range",
-                                        start_date=df["ts"].min().date() if not df.empty else None,
-                                        end_date=df["ts"].max().date() if not df.empty else None,
-                                        minimum_nights=0,
-                                    ),
-                                ],
-                                className="filter-item",
-                            ),
+                            create_social_date_range_filter(df),
                             html.Div(
                                 [
                                     html.Label("Mode", className="filter-label"),
@@ -331,6 +326,29 @@ def create_tab_social_layout(df: pd.DataFrame) -> Component:
                                     ),
                                 ],
                                 className="filter-item",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label(
+                                        "Exclude Parent Genres (Level 0)",
+                                        className="filter-label",
+                                    ),
+                                    dcc.RadioItems(
+                                        id="social-genre-hide-level0-radio",
+                                        options=[
+                                            {"label": "Yes", "value": True},
+                                            {"label": "No", "value": False},
+                                        ],
+                                        value=False,
+                                        className="radio-group",
+                                        inputClassName="radio-pill",
+                                        labelClassName="radio-pill-label",
+                                        persistence=True,
+                                        persistence_type="local",
+                                    ),
+                                ],
+                                className="filter-item",
+                                id="social-genre-hide-level0-container",
                             ),
                         ],
                         className="filters-section",

--- a/dashboard/layouts/layouts.py
+++ b/dashboard/layouts/layouts.py
@@ -34,6 +34,26 @@ def _create_user_selector(df: pd.DataFrame) -> Component:
     )
 
 
+def _create_social_user_selector(df: pd.DataFrame) -> Component:
+    users = sorted(df.get("user_id", pd.Series(dtype=str)).dropna().unique())
+    return html.Div(
+        [
+            html.Label("Select Users (2–3)", className="filter-label"),
+            dcc.Dropdown(
+                id="social-users-dropdown",
+                options=[{"label": u, "value": u} for u in users],
+                value=[],
+                multi=True,
+                placeholder="Choose users to compare…",
+                persistence=True,
+                persistence_type="local",
+                className="dropdown",
+            ),
+        ],
+        className="filter-item",
+    )
+
+
 def create_layout(df: pd.DataFrame) -> Component:
     """Generate the main dashboard layout.
 
@@ -125,6 +145,10 @@ def create_layout(df: pd.DataFrame) -> Component:
                             dcc.Tab(
                                 label="📈 Trends",
                                 children=[create_tab_two_layout(df)],
+                            ),
+                            dcc.Tab(
+                                label="👥 Social",
+                                children=[create_tab_social_layout(df)],
                             ),
                         ]
                     ),
@@ -257,6 +281,82 @@ def create_tab_two_layout(
             # Store for genre hide-level0 toggle (to avoid referencing
             # dynamic controls as Inputs/State in other callbacks)
             dcc.Store(id="genre-hide-level0-store"),
+        ],
+        className="container",
+    )
+
+
+def create_tab_social_layout(df: pd.DataFrame) -> Component:
+    """Create layout for the Social tab (multi-user comparison via Venn).
+
+    Contains: local date range, user multiselect, mode radio, venn display, and details.
+    """
+    return html.Div(
+        [
+            html.Div(
+                [
+                    html.H3("Filters", className="card-title"),
+                    html.Div(
+                        [
+                            _create_social_user_selector(df),
+                            # Local date range (independent of Trends tab)
+                            html.Div(
+                                [
+                                    html.Label("Select Date Range", className="filter-label"),
+                                    dcc.DatePickerRange(
+                                        id="social-date-range",
+                                        start_date=df["ts"].min().date() if not df.empty else None,
+                                        end_date=df["ts"].max().date() if not df.empty else None,
+                                        minimum_nights=0,
+                                    ),
+                                ],
+                                className="filter-item",
+                            ),
+                            html.Div(
+                                [
+                                    html.Label("Mode", className="filter-label"),
+                                    dcc.RadioItems(
+                                        id="social-mode",
+                                        options=[
+                                            {"label": "Tracks", "value": "tracks"},
+                                            {"label": "Artists", "value": "artists"},
+                                            {"label": "Genres", "value": "genres"},
+                                        ],
+                                        value="tracks",
+                                        className="radio-group",
+                                        inputClassName="radio-pill",
+                                        labelClassName="radio-pill-label",
+                                        persistence=True,
+                                        persistence_type="local",
+                                    ),
+                                ],
+                                className="filter-item",
+                            ),
+                        ],
+                        className="filters-section",
+                    ),
+                ],
+                className="card",
+            ),
+            # Content
+            html.Div(
+                [
+                    html.H3("Comparison", className="card-title"),
+                    dcc.Loading(
+                        children=dcc.Graph(id="social-venn-graph", figure={}),
+                        delay_show=0,
+                        overlay_style={
+                            "visibility": "visible",
+                            "backgroundColor": "rgba(0,0,0,0.15)",
+                        },
+                        type="default",
+                    ),
+                    html.Div(id="social-region-lists"),
+                ],
+                className="card",
+            ),
+            # Store for computed social data
+            dcc.Store(id="social-data"),
         ],
         className="container",
     )

--- a/src/metrics/social.py
+++ b/src/metrics/social.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import pandas as pd
+
+Mode = Literal["tracks", "artists", "genres"]
+
+
+@dataclass(frozen=True)
+class RegionItem:
+    id: str
+    name: str
+    joint_rank: float
+    ranks: dict[str, int]
+    counts: dict[str, int]
+
+
+def _register_list_param(con, name: str, values: Iterable[str] | None) -> str:
+    """Register a small list as a temp relation and return its table name."""
+    if not values:
+        return ""
+    df = pd.DataFrame({"val": list(values)})
+    relname = f"tmp_{name}"
+    with contextlib.suppress(Exception):
+        con.unregister(relname)
+    con.register(relname, df)
+    return relname
+
+
+def _base_plays_sql(
+    *,
+    users_rel: str,
+    exclude_december: bool,
+    remove_incognito: bool,
+    rel_tracks: str,
+    rel_artists: str,
+    rel_albums: str,
+    rel_genres: str,
+) -> str:
+    # Build optional WHERE fragments
+    filters = [
+        f"p.user_id IN (SELECT val FROM {users_rel})",
+        "COALESCE(p.skipped, FALSE) = FALSE",
+        "COALESCE(p.duration_ms, 0) > 0",
+        "COALESCE(p.reason_start, 'unknown') <> 'unknown'",
+        "COALESCE(p.reason_end, 'unknown') <> 'unknown'",
+    ]
+    if exclude_december:
+        filters.append("EXTRACT(MONTH FROM p.played_at) <> 12")
+    if remove_incognito:
+        filters.append("COALESCE(p.incognito_mode, FALSE) = FALSE")
+
+    extra_exclusions: list[str] = []
+    if rel_tracks:
+        extra_exclusions.append(f"COALESCE(t.track_name, '') NOT IN (SELECT val FROM {rel_tracks})")
+    if rel_artists:
+        extra_exclusions.append(
+            f"COALESCE(ar.artist_name, '') NOT IN (SELECT val FROM {rel_artists})"
+        )
+    if rel_albums:
+        extra_exclusions.append(
+            f"COALESCE(al.album_name, '') NOT IN (SELECT val FROM {rel_albums})"
+        )
+    # Genre exclusions (by name) via artist_genres + genre_hierarchy when present
+    if rel_genres:
+        extra_exclusions.append(
+            "NOT EXISTS (\n"
+            "  SELECT 1\n"
+            "  FROM bridge_track_artists b\n"
+            "  JOIN artist_genres ag ON ag.artist_id = b.artist_id\n"
+            "  JOIN dim_genres g ON g.genre_id = ag.genre_id\n"
+            "  LEFT JOIN genre_hierarchy gh ON gh.child_genre_id = g.genre_id\n"
+            "  LEFT JOIN dim_genres pg ON pg.genre_id = gh.parent_genre_id\n"
+            "  WHERE b.role = 'primary' AND b.track_id = p.track_id\n"
+            f"    AND (lower(g.name) IN (SELECT lower(val) FROM {rel_genres})\n"
+            f"         OR lower(COALESCE(pg.name, '')) IN (SELECT lower(val) FROM {rel_genres}))\n"
+            ")"
+        )
+
+    where_clause = " AND\n          ".join(filters + extra_exclusions)
+
+    return (
+        "WITH base AS (\n"
+        "  SELECT p.user_id, p.track_id, p.played_at\n"
+        "  FROM fact_plays p\n"
+        "  LEFT JOIN dim_tracks t ON t.track_id = p.track_id\n"
+        "  LEFT JOIN bridge_track_artists b ON b.track_id = p.track_id AND b.role = 'primary'\n"
+        "  LEFT JOIN dim_artists ar ON ar.artist_id = b.artist_id\n"
+        "  LEFT JOIN dim_albums al ON al.album_id = t.album_id\n"
+        f"  WHERE {where_clause}\n"
+        ")\n"
+    )
+
+
+def _ranks_sql(mode: Mode) -> str:
+    """Return the CTEs for per-user counts and ranks, prefixed with a comma.
+
+    Must follow immediately after "WITH base AS (...)".
+    """
+    if mode == "tracks":
+        return "".join(
+            [
+                ",\n",
+                "counts AS (\n",
+                "  SELECT b.user_id, t.track_id AS entity_id, t.track_name AS entity_name, COUNT(*) AS play_count\n",
+                "  FROM base b\n",
+                "  JOIN dim_tracks t ON t.track_id = b.track_id\n",
+                "  GROUP BY 1,2,3\n",
+                "),\n",
+                "ranks AS (\n",
+                "  SELECT user_id, entity_id, entity_name, play_count,\n",
+                "         DENSE_RANK() OVER (PARTITION BY user_id ORDER BY play_count DESC, entity_name ASC) AS rnk\n",
+                "  FROM counts\n",
+                ")\n",
+            ]
+        )
+    if mode == "artists":
+        return "".join(
+            [
+                ",\n",
+                "track_primary AS (\n",
+                "  SELECT b.user_id, b.track_id, a.artist_id, ar.artist_name\n",
+                "  FROM base b\n",
+                "  JOIN bridge_track_artists a ON a.track_id = b.track_id AND a.role = 'primary'\n",
+                "  JOIN dim_artists ar ON ar.artist_id = a.artist_id\n",
+                "),\n",
+                "counts AS (\n",
+                "  SELECT user_id, artist_id AS entity_id, artist_name AS entity_name, COUNT(*) AS play_count\n",
+                "  FROM track_primary\n",
+                "  GROUP BY 1,2,3\n",
+                "),\n",
+                "ranks AS (\n",
+                "  SELECT user_id, entity_id, entity_name, play_count,\n",
+                "         DENSE_RANK() OVER (PARTITION BY user_id ORDER BY play_count DESC, entity_name ASC) AS rnk\n",
+                "  FROM counts\n",
+                ")\n",
+            ]
+        )
+    # genres
+    return "".join(
+        [
+            ",\n",
+            "track_primary AS (\n",
+            "  SELECT b.user_id, b.track_id, a.artist_id\n",
+            "  FROM base b\n",
+            "  JOIN bridge_track_artists a ON a.track_id = b.track_id AND a.role = 'primary'\n",
+            "),\n",
+            "artist_genre AS (\n",
+            "  SELECT tp.user_id, g.genre_id AS entity_id, dg.name AS entity_name\n",
+            "  FROM track_primary tp\n",
+            "  JOIN artist_genres g ON g.artist_id = tp.artist_id\n",
+            "  JOIN dim_genres dg ON dg.genre_id = g.genre_id\n",
+            "),\n",
+            "counts AS (\n",
+            "  SELECT user_id, entity_id, entity_name, COUNT(*) AS play_count\n",
+            "  FROM artist_genre\n",
+            "  GROUP BY 1,2,3\n",
+            "),\n",
+            "ranks AS (\n",
+            "  SELECT user_id, entity_id, entity_name, play_count,\n",
+            "         DENSE_RANK() OVER (PARTITION BY user_id ORDER BY play_count DESC, entity_name ASC) AS rnk\n",
+            "  FROM counts\n",
+            ")\n",
+        ]
+    )
+
+
+def _build_users_rel(con, users: Iterable[str]) -> str:
+    df = pd.DataFrame({"val": list(users)})
+    rel = "tmp_users"
+    with contextlib.suppress(Exception):
+        con.unregister(rel)
+    con.register(rel, df)
+    return rel
+
+
+def compute_social_regions(
+    *,
+    con: Any,
+    users: list[str],
+    start: pd.Timestamp | None,
+    end: pd.Timestamp | None,
+    mode: Mode = "tracks",
+    exclude_december: bool = True,
+    remove_incognito: bool = True,
+    excluded_tracks: Iterable[str] | None = None,
+    excluded_artists: Iterable[str] | None = None,
+    excluded_albums: Iterable[str] | None = None,
+    excluded_genres: Iterable[str] | None = None,
+    limit_per_region: int = 10,
+) -> dict:
+    """Compute Venn regions for 2–3 users with per-user ranks and joint ranks.
+
+    Returns a dict with keys: users, mode, regions -> mapping of region_key to data.
+    Region keys for 2 users: "U1_only", "U2_only", "U1_U2". For 3 users, adds
+    "U1_only", "U2_only", "U3_only", "U1_U2", "U1_U3", "U2_U3", "U1_U2_U3".
+    Keys include the actual user_id values in order.
+    """
+    if not users or len(users) < 2 or len(users) > 3:
+        raise ValueError("users must contain 2 or 3 user ids")
+
+    # Prepare parameter relations
+    users_rel = _build_users_rel(con, users)
+    rel_tracks = _register_list_param(con, "excluded_tracks", excluded_tracks)
+    rel_artists = _register_list_param(con, "excluded_artists", excluded_artists)
+    rel_albums = _register_list_param(con, "excluded_albums", excluded_albums)
+    rel_genres = _register_list_param(con, "excluded_genres", excluded_genres)
+
+    # Register date bounds if provided
+    params: list[Any] = []
+    date_clause = ""
+    if start is not None:
+        date_clause += " AND p.played_at >= ?"
+        params.append(pd.to_datetime(start).to_pydatetime())
+    if end is not None:
+        date_clause += " AND p.played_at <= ?"
+        params.append(pd.to_datetime(end).to_pydatetime())
+
+    base = _base_plays_sql(
+        users_rel=users_rel,
+        exclude_december=exclude_december,
+        remove_incognito=remove_incognito,
+        rel_tracks=rel_tracks,
+        rel_artists=rel_artists,
+        rel_albums=rel_albums,
+        rel_genres=rel_genres,
+    ).replace("WHERE ", f"WHERE 1=1{date_clause} AND ")
+
+    ranks = _ranks_sql(mode)
+
+    sql = base + ranks + "SELECT user_id, entity_id, entity_name, play_count, rnk FROM ranks;"
+
+    df = con.execute(sql, params).df()
+    if df.empty:
+        return {
+            "users": users,
+            "mode": mode,
+            "regions": {},
+        }
+
+    # Build per-user rankings and sets
+    per_user = {u: df[df.user_id == u].copy() for u in users}
+    for u in users:
+        per_user[u].sort_values(["rnk", "entity_name"], inplace=True)
+
+    # Helper to collect items for a set of users
+    def _region_entities(required: tuple[str, ...], excluded: tuple[str, ...]) -> pd.DataFrame:
+        req_sets = []
+        for u in required:
+            req_sets.append(set(per_user[u]["entity_id"].unique().tolist()))
+        if not req_sets:
+            return pd.DataFrame(columns=df.columns)
+        entities = set.intersection(*req_sets)
+        for u in excluded:
+            entities -= set(per_user[u]["entity_id"].unique().tolist())
+        if not entities:
+            return pd.DataFrame(columns=df.columns)
+        subset = df[df["entity_id"].isin(list(entities)) & df["user_id"].isin(list(required))]
+        # Compute joint rank
+        agg = (
+            subset.groupby(["entity_id", "entity_name"], as_index=False)
+            .agg(joint_rank=("rnk", "mean"))
+            .sort_values(["joint_rank", "entity_name"])
+        )
+        return agg
+
+    regions: dict[str, list[RegionItem]] = {}
+
+    # Build region keys using actual user ids for clarity
+    if len(users) == 2:
+        u1, u2 = users
+        # Intersection
+        inter = _region_entities((u1, u2), tuple())
+        top = inter.head(limit_per_region)
+        items: list[RegionItem] = []
+        for row in top.itertuples(index=False):
+            eid = str(row.entity_id)
+            nm = str(row.entity_name)
+            # gather counts/ranks per user
+            ranks_counts: dict[str, tuple[int, int]] = {}
+            for u in (u1, u2):
+                r = per_user[u]
+                rr = r[r.entity_id == row.entity_id].sort_values(["rnk", "entity_name"]).iloc[0]
+                ranks_counts[u] = (int(rr.rnk), int(rr.play_count))
+            items.append(
+                RegionItem(
+                    id=eid,
+                    name=nm,
+                    joint_rank=float(row.joint_rank),
+                    ranks={k: v[0] for k, v in ranks_counts.items()},
+                    counts={k: v[1] for k, v in ranks_counts.items()},
+                )
+            )
+        regions[f"{u1}_{u2}"] = [item.__dict__ for item in items]
+
+        # Non-intersections: top per user overall (duplicates with intersection allowed)
+        for u in (u1, u2):
+            ru = per_user[u]
+            ru_sorted = ru.sort_values(["rnk", "entity_name"]).head(limit_per_region)
+            u_items: list[RegionItem] = []
+            for rr in ru_sorted.itertuples(index=False):
+                u_items.append(
+                    RegionItem(
+                        id=str(rr.entity_id),
+                        name=str(rr.entity_name),
+                        joint_rank=float(rr.rnk),
+                        ranks={u: int(rr.rnk)},
+                        counts={u: int(rr.play_count)},
+                    )
+                )
+            regions[f"{u}_only"] = [ri.__dict__ for ri in u_items]
+    else:
+        u1, u2, u3 = users
+        # 3-way intersection
+        inter3 = _region_entities((u1, u2, u3), tuple())
+        items3 = []
+        for row in inter3.head(limit_per_region).itertuples(index=False):
+            ranks_counts: dict[str, tuple[int, int]] = {}
+            for u in (u1, u2, u3):
+                r = per_user[u]
+                rr = r[r.entity_id == row.entity_id].sort_values(["rnk", "entity_name"]).iloc[0]
+                ranks_counts[u] = (int(rr.rnk), int(rr.play_count))
+            items3.append(
+                RegionItem(
+                    id=str(row.entity_id),
+                    name=str(row.entity_name),
+                    joint_rank=float(row.joint_rank),
+                    ranks={k: v[0] for k, v in ranks_counts.items()},
+                    counts={k: v[1] for k, v in ranks_counts.items()},
+                ).__dict__
+            )
+        regions[f"{u1}_{u2}_{u3}"] = items3
+
+        # Exactly-two intersections
+        pairs: list[tuple[tuple[str, ...], tuple[str, ...]]] = [
+            ((u1, u2), (u3,)),
+            ((u1, u3), (u2,)),
+            ((u2, u3), (u1,)),
+        ]
+        for req, exc in pairs:
+            dfp = _region_entities(req, exc)
+            items_pair = []
+            for row in dfp.head(limit_per_region).itertuples(index=False):
+                ranks_counts: dict[str, tuple[int, int]] = {}
+                for u in req:
+                    r = per_user[u]
+                    rr = r[r.entity_id == row.entity_id].sort_values(["rnk", "entity_name"]).iloc[0]
+                    ranks_counts[u] = (int(rr.rnk), int(rr.play_count))
+                items_pair.append(
+                    RegionItem(
+                        id=str(row.entity_id),
+                        name=str(row.entity_name),
+                        joint_rank=float(row.joint_rank),
+                        ranks={k: v[0] for k, v in ranks_counts.items()},
+                        counts={k: v[1] for k, v in ranks_counts.items()},
+                    ).__dict__
+                )
+            regions["_".join(req)] = items_pair
+
+        # Non-intersections per user (top overall)
+        for u in (u1, u2, u3):
+            ru = per_user[u]
+            ru_sorted = ru.sort_values(["rnk", "entity_name"]).head(limit_per_region)
+            u_items: list[RegionItem] = []
+            for rr in ru_sorted.itertuples(index=False):
+                u_items.append(
+                    RegionItem(
+                        id=str(rr.entity_id),
+                        name=str(rr.entity_name),
+                        joint_rank=float(rr.rnk),
+                        ranks={u: int(rr.rnk)},
+                        counts={u: int(rr.play_count)},
+                    )
+                )
+            regions[f"{u}_only"] = [ri.__dict__ for ri in u_items]
+
+    return {
+        "users": users,
+        "mode": mode,
+        "regions": regions,
+    }

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -93,10 +93,12 @@ def test_social_tracks_two_users_basic():
         inter = regions.get("u1_u2", [])
         assert any(item["name"] == "Track One" for item in inter)
         assert all(item["name"] != "Track Two" for item in inter)
-        # u1_only should include its top ranks with Track One first
+        # u1_only excludes shared tracks and enforces expected top rank for user1
         u1_only = regions.get("u1_only", [])
         assert len(u1_only) > 0
-        assert u1_only[0]["name"] in {"Track One", "Track Two"}
+        assert "Track One" not in {t["name"] for t in u1_only}
+        # Top exclusive for u1 should be Track Two (shared t1 excluded)
+        assert u1_only[0]["name"] == "Track Two"
     finally:
         con.close()
 

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -1,0 +1,150 @@
+import pandas as pd
+
+
+def _setup_duckdb_with_minimal_schema(con):
+    con.execute(
+        """
+        CREATE TABLE dim_tracks (
+            track_id   TEXT PRIMARY KEY,
+            track_name TEXT NOT NULL,
+            album_id   TEXT
+        );
+        CREATE TABLE dim_artists (
+            artist_id   TEXT PRIMARY KEY,
+            artist_name TEXT NOT NULL
+        );
+        CREATE TABLE bridge_track_artists (
+            track_id  TEXT NOT NULL,
+            artist_id TEXT NOT NULL,
+            role      TEXT NOT NULL
+        );
+        CREATE TABLE fact_plays (
+            user_id TEXT NOT NULL,
+            track_id TEXT NOT NULL,
+            played_at TIMESTAMP NOT NULL,
+            skipped BOOLEAN,
+            incognito_mode BOOLEAN,
+            duration_ms INTEGER,
+            reason_start TEXT,
+            reason_end TEXT
+        );
+        CREATE TABLE dim_genres (
+            genre_id   INTEGER PRIMARY KEY,
+            name       TEXT NOT NULL
+        );
+        CREATE TABLE artist_genres (
+            artist_id  TEXT NOT NULL,
+            genre_id   INTEGER NOT NULL
+        );
+        """
+    )
+
+
+def test_social_tracks_two_users_basic():
+    import duckdb
+
+    from src.metrics.social import compute_social_regions
+
+    con = duckdb.connect(":memory:")
+    try:
+        _setup_duckdb_with_minimal_schema(con)
+        # Tracks and artists
+        con.executemany(
+            "INSERT INTO dim_tracks(track_id, track_name, album_id) VALUES (?, ?, ?)",
+            [("t1", "Track One", None), ("t2", "Track Two", None), ("t3", "Track Three", None)],
+        )
+        con.executemany(
+            "INSERT INTO dim_artists(artist_id, artist_name) VALUES (?, ?)",
+            [("a1", "Artist A"), ("a2", "Artist B")],
+        )
+        con.executemany(
+            "INSERT INTO bridge_track_artists(track_id, artist_id, role) VALUES (?, ?, ?)",
+            [("t1", "a1", "primary"), ("t2", "a1", "primary"), ("t3", "a2", "primary")],
+        )
+
+        # Plays: u1 plays t1 twice and t2 once; u2 plays t1 once and t3 once
+        rows = []
+
+        def add_play(user, tid, ts):
+            rows.append((user, tid, ts, False, False, 60_000, "fw", "fw"))
+
+        add_play("u1", "t1", "2024-01-01 10:00:00")
+        add_play("u1", "t1", "2024-01-01 11:00:00")
+        add_play("u1", "t2", "2024-01-02 10:00:00")
+        add_play("u2", "t1", "2024-01-01 12:00:00")
+        add_play("u2", "t3", "2024-01-03 09:00:00")
+        con.executemany(
+            "INSERT INTO fact_plays(user_id, track_id, played_at, skipped, incognito_mode, duration_ms, reason_start, reason_end) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+        out = compute_social_regions(
+            con=con,
+            users=["u1", "u2"],
+            start=pd.Timestamp("2024-01-01"),
+            end=pd.Timestamp("2024-01-31"),
+            mode="tracks",
+            exclude_december=True,
+            remove_incognito=True,
+        )
+        assert out["users"] == ["u1", "u2"]
+        regions = out["regions"]
+        # Intersection region should include t1 only
+        inter = regions.get("u1_u2", [])
+        assert any(item["name"] == "Track One" for item in inter)
+        assert all(item["name"] != "Track Two" for item in inter)
+        # u1_only should include its top ranks with Track One first
+        u1_only = regions.get("u1_only", [])
+        assert len(u1_only) > 0
+        assert u1_only[0]["name"] in {"Track One", "Track Two"}
+    finally:
+        con.close()
+
+
+def test_social_artists_and_genres():
+    import duckdb
+
+    from src.metrics.social import compute_social_regions
+
+    con = duckdb.connect(":memory:")
+    try:
+        _setup_duckdb_with_minimal_schema(con)
+        con.executemany(
+            "INSERT INTO dim_tracks(track_id, track_name, album_id) VALUES (?, ?, ?)",
+            [("t1", "T1", None), ("t2", "T2", None)],
+        )
+        con.executemany(
+            "INSERT INTO dim_artists(artist_id, artist_name) VALUES (?, ?)",
+            [("a1", "Alpha"), ("a2", "Beta")],
+        )
+        con.executemany(
+            "INSERT INTO bridge_track_artists(track_id, artist_id, role) VALUES (?, ?, ?)",
+            [("t1", "a1", "primary"), ("t2", "a2", "primary")],
+        )
+        con.executemany(
+            "INSERT INTO dim_genres(genre_id, name) VALUES (?, ?)", [(1, "Pop"), (2, "Rock")]
+        )
+        con.executemany(
+            "INSERT INTO artist_genres(artist_id, genre_id) VALUES (?, ?)", [("a1", 1), ("a2", 2)]
+        )
+        rows = [
+            ("u1", "t1", "2024-02-01 10:00:00", False, False, 60_000, "fw", "fw"),
+            ("u2", "t2", "2024-02-01 10:00:00", False, False, 60_000, "fw", "fw"),
+        ]
+        con.executemany(
+            "INSERT INTO fact_plays(user_id, track_id, played_at, skipped, incognito_mode, duration_ms, reason_start, reason_end) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+        artists = compute_social_regions(
+            con=con, users=["u1", "u2"], start=None, end=None, mode="artists"
+        )
+        assert artists["regions"]["u1_u2"] == []  # no shared artists
+
+        genres = compute_social_regions(
+            con=con, users=["u1", "u2"], start=None, end=None, mode="genres"
+        )
+        # Different single-genre plays; no intersection expected
+        assert genres["regions"]["u1_u2"] == []
+    finally:
+        con.close()


### PR DESCRIPTION
Adds a new social tab to the application which lets users compare their music taste against other users within the system. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Social tab supporting 2–3 user comparisons with multi-user selector, mode switch (Tracks/Artists/Genres), hide-parent-genres toggle, independent date-range controls with presets/reset, and stores for UI state.
  - Interactive Venn-style comparison visuals with region lists, selectable regions, tooltips, “show more” paging, and consistent theming/loading behavior.

- **Tests**
  - Added automated tests validating social comparisons across tracks, artists, and genres, date-window behavior, and intersection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->