### PR TITLE
Addresses Threadpool executors

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -221,7 +221,7 @@ class SpotifyDataCollector:
                 futures = {
                     executor.submit(
                         self._fetch_with_retry,
-                        lambda b: self.spotify_client.tracks(b)["tracks"],
+                        lambda _batch=batch: self.spotify_client.tracks(_batch)["tracks"],
                         batch,
                     ): batch
                     for batch in batches
@@ -262,7 +262,7 @@ class SpotifyDataCollector:
                 futures = {
                     executor.submit(
                         self._fetch_with_retry,
-                        lambda b: self.spotify_client.artists(b)["artists"],
+                        lambda _batch=batch: self.spotify_client.artists(_batch)["artists"],
                         batch,
                     ): batch
                     for batch in batches
@@ -303,7 +303,7 @@ class SpotifyDataCollector:
                 futures = {
                     executor.submit(
                         self._fetch_with_retry,
-                        lambda b: self.spotify_client.albums(b)["albums"],
+                        lambda _batch=batch: self.spotify_client.albums(_batch)["albums"],
                         batch,
                     ): batch
                     for batch in batches


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures each thread uses the intended batch when fetching from Spotify, avoiding late-binding of the loop variable.
> 
> - Updates `fetch_tracks`, `fetch_artists`, and `fetch_albums` to capture `batch` in the lambda (`lambda _batch=batch: ...`) used by `ThreadPoolExecutor` futures
> - Prevents incorrect batch requests during concurrent execution and improves reliability of caching and DB population steps that depend on these fetches
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb7234eccd5a6895fb2ef7809ddf5b7e6c648063. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with concurrent batch fetch operations that could result in incorrect batches being processed, ensuring accurate data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->